### PR TITLE
Define more complete default image styles

### DIFF
--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -20,13 +20,21 @@
 }
 
 // Image widget's styles.
-.ck-widget.image {
+.image {
 	text-align: center;
 	clear: both;
 
 	&.image-style-side {
-		display: inline-block;
 		float: right;
 		margin-left: 0.8em;
+		max-width: 50%;
 	}
+}
+
+.image > img {
+	// Prevent unnecessary margins caused by line-height (see #44).
+	display: block;
+
+	// Center the image if its width is smaller than content's width.
+	margin: 0 auto;
 }


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#5062.

I was also able to remove this from ckeditor5.github.io:

```
-.ck-editor .ck-widget {
-    padding: 0;
-    line-height: 0;
-    font-size: 0;
-}
```