### PR TITLE
Moved ImageBalloonPanelView focus tracking to init() method

### DIFF
--- a/src/ui/imageballoonpanelview.js
+++ b/src/ui/imageballoonpanelview.js
@@ -54,9 +54,6 @@ export default class ImageBalloonPanelView extends BalloonPanelView {
 		this.editor = editor;
 		const editingView = editor.editing.view;
 
-		// Let the focusTracker know about new focusable UI element.
-		editor.ui.focusTracker.add( this.element );
-
 		// Hide the balloon if editor had focus and now focus is lost.
 		this.listenTo( editor.ui.focusTracker, 'change:isFocused', ( evt, name, is, was ) => {
 			if ( was && !is ) {
@@ -83,6 +80,16 @@ export default class ImageBalloonPanelView extends BalloonPanelView {
 		this._throttledAttach = throttle( () => {
 			this._attach();
 		}, 100 );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		super.init();
+
+		// Let the focusTracker know about new focusable UI element.
+		this.editor.ui.focusTracker.add( this.element );
 	}
 
 	/**

--- a/src/ui/imageballoonpanelview.js
+++ b/src/ui/imageballoonpanelview.js
@@ -86,10 +86,10 @@ export default class ImageBalloonPanelView extends BalloonPanelView {
 	 * @inheritDoc
 	 */
 	init() {
-		super.init();
-
 		// Let the focusTracker know about new focusable UI element.
 		this.editor.ui.focusTracker.add( this.element );
+
+		return super.init();
 	}
 
 	/**

--- a/tests/ui/imageballoonpanelview.js
+++ b/tests/ui/imageballoonpanelview.js
@@ -36,14 +36,25 @@ describe( 'ImageBalloonPanel', () => {
 		return editor.destroy();
 	} );
 
+	it( 'init method should return a promise', () => {
+		const panel = new ImageBalloonPanel( editor );
+		const promise  = panel.init();
+
+		expect( promise ).to.be.instanceof( Promise );
+
+		return promise;
+	} );
+
 	it( 'should add element to editor\'s focus tracker after init', () => {
 		const spy = sinon.spy( editor.ui.focusTracker, 'add' );
 		const panel = new ImageBalloonPanel( editor );
 
 		sinon.assert.notCalled( spy );
-		panel.init();
-		sinon.assert.calledOnce( spy );
-		sinon.assert.calledWithExactly( spy, panel.element );
+
+		return panel.init().then( () => {
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, panel.element );
+		} );
 	} );
 
 	it( 'should detach panel when focus is removed', () => {

--- a/tests/ui/imageballoonpanelview.js
+++ b/tests/ui/imageballoonpanelview.js
@@ -36,10 +36,12 @@ describe( 'ImageBalloonPanel', () => {
 		return editor.destroy();
 	} );
 
-	it( 'should add element to editor\'s focus tracker', () => {
+	it( 'should add element to editor\'s focus tracker after init', () => {
 		const spy = sinon.spy( editor.ui.focusTracker, 'add' );
 		const panel = new ImageBalloonPanel( editor );
 
+		sinon.assert.notCalled( spy );
+		panel.init();
 		sinon.assert.calledOnce( spy );
 		sinon.assert.calledWithExactly( spy, panel.element );
 	} );


### PR DESCRIPTION
### Proposed merge commit message

Fix: Moved focus tracking setup in `ImageBalloonPanelView` to `init()` method. Closes ckeditor/ckeditor5#5060.

