### PR TITLE
Used 'low-vision' icon instead of 'input' for ImageTextAlternative.

### DIFF
--- a/src/imagetextalternative.js
+++ b/src/imagetextalternative.js
@@ -16,7 +16,7 @@ import ImageToolbar from './imagetoolbar';
 import TextAlternativeFormView from './imagetextalternative/ui/textalternativeformview';
 import ImageBalloonPanel from './image/ui/imageballoonpanelview';
 
-import textAlternativeIcon from '@ckeditor/ckeditor5-core/theme/icons/input.svg';
+import textAlternativeIcon from '@ckeditor/ckeditor5-core/theme/icons/low-vision.svg';
 import '../theme/imagetextalternative/theme.scss';
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Used "low-vision" icon instead of "input" for text alternative button. Closes ckeditor/ckeditor5#5069.

Requires https://github.com/ckeditor/ckeditor5-core/pull/69.