### PR TITLE
T/64: Added separators between ImageTextAlternative and ImageStyle plugin buttons in ImageToolbar

### DIFF
--- a/src/imagestyle.js
+++ b/src/imagestyle.js
@@ -40,6 +40,10 @@ export default class ImageStyle extends Plugin {
 		const defaultImageToolbarConfig = this.editor.config.get( 'image.defaultToolbar' );
 
 		if ( defaultImageToolbarConfig ) {
+			if ( defaultImageToolbarConfig.length ) {
+				defaultImageToolbarConfig.push( '|' );
+			}
+
 			styles.forEach( style => defaultImageToolbarConfig.push( style.name ) );
 		}
 	}

--- a/src/imagetextalternative.js
+++ b/src/imagetextalternative.js
@@ -42,6 +42,10 @@ export default class ImageTextAlternative extends Plugin {
 		const defaultImageToolbarConfig = this.editor.config.get( 'image.defaultToolbar' );
 
 		if ( defaultImageToolbarConfig ) {
+			if ( defaultImageToolbarConfig.length ) {
+				defaultImageToolbarConfig.push( '|' );
+			}
+
 			defaultImageToolbarConfig.push( 'imageTextAlternative' );
 		}
 

--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -12,6 +12,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
 import { isImageWidget } from './image/utils';
 import ImageBalloonPanel from './image/ui/imageballoonpanelview';
+import { getItemsFromConfig } from '@ckeditor/ckeditor5-ui/src/toolbar/utils';
 
 /**
  * Image toolbar class. Creates image toolbar placed inside balloon panel that is showed when image widget is selected.
@@ -69,9 +70,7 @@ export default class ImageToolbar extends Plugin {
 		promises.push( panel.content.add( toolbar ) );
 
 		// Add buttons to the toolbar.
-		for ( let name of toolbarConfig ) {
-			promises.push( toolbar.items.add( editor.ui.componentFactory.create( name ) ) );
-		}
+		promises.push( getItemsFromConfig( toolbarConfig, toolbar.items, editor.ui.componentFactory ) );
 
 		// Add balloon panel to editor's UI.
 		promises.push( editor.ui.view.body.add( panel ) );

--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -12,7 +12,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
 import { isImageWidget } from './image/utils';
 import ImageBalloonPanel from './image/ui/imageballoonpanelview';
-import { getItemsFromConfig } from '@ckeditor/ckeditor5-ui/src/toolbar/utils';
+import getItemsFromConfig from '@ckeditor/ckeditor5-ui/src/toolbar/getitemsfromconfig';
 
 /**
  * Image toolbar class. Creates image toolbar placed inside balloon panel that is showed when image widget is selected.

--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -12,7 +12,6 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
 import { isImageWidget } from './image/utils';
 import ImageBalloonPanel from './image/ui/imageballoonpanelview';
-import getItemsFromConfig from '@ckeditor/ckeditor5-ui/src/toolbar/getitemsfromconfig';
 
 /**
  * Image toolbar class. Creates image toolbar placed inside balloon panel that is showed when image widget is selected.
@@ -70,7 +69,7 @@ export default class ImageToolbar extends Plugin {
 		promises.push( panel.content.add( toolbar ) );
 
 		// Add buttons to the toolbar.
-		promises.push( getItemsFromConfig( toolbarConfig, toolbar.items, editor.ui.componentFactory ) );
+		promises.push( toolbar.fillFromConfig( toolbarConfig, editor.ui.componentFactory ) );
 
 		// Add balloon panel to editor's UI.
 		promises.push( editor.ui.view.body.add( panel ) );

--- a/tests/imagestyle.js
+++ b/tests/imagestyle.js
@@ -3,6 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import ImageToolbar from '../src/imagetoolbar';
 import ImageStyle from '../src/imagestyle';
@@ -84,6 +85,28 @@ describe( 'ImageStyle', () => {
 
 				newEditor.destroy();
 			} );
+	} );
+
+	it( 'should add separator before the button if toolbar is present and already has items', () => {
+		const editorElement = global.document.createElement( 'div' );
+		global.document.body.appendChild( editorElement );
+
+		const FooPlugin = class extends Plugin {
+			init() {
+				this.editor.ui.componentFactory.add( 'foo', () => new ButtonView() );
+
+				this.editor.config.get( 'image.defaultToolbar' ).push( 'foo' );
+			}
+		};
+
+		return ClassicTestEditor.create( editorElement, {
+			plugins: [ FooPlugin, ImageStyle, ImageToolbar ]
+		} )
+		.then( newEditor => {
+			expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'foo', '|', 'imageStyleFull', 'imageStyleSide' ] );
+
+			newEditor.destroy();
+		} );
 	} );
 
 	it( 'should not add buttons to image toolbar if configuration is present', () => {

--- a/tests/imagetextalternative.js
+++ b/tests/imagetextalternative.js
@@ -3,6 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Image from '../src/image';
 import ImageToolbar from '../src/imagetoolbar';
@@ -105,6 +106,28 @@ describe( 'ImageTextAlternative', () => {
 			} )
 			.then( newEditor => {
 				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'imageTextAlternative' ] );
+
+				newEditor.destroy();
+			} );
+		} );
+
+		it( 'should add separator before the button if toolbar is present and already has items', () => {
+			const editorElement = global.document.createElement( 'div' );
+			global.document.body.appendChild( editorElement );
+
+			const FooPlugin = class extends Plugin {
+				init() {
+					this.editor.ui.componentFactory.add( 'foo', () => new ButtonView() );
+
+					this.editor.config.get( 'image.defaultToolbar' ).push( 'foo' );
+				}
+			};
+
+			return ClassicTestEditor.create( editorElement, {
+				plugins: [ FooPlugin, ImageTextAlternative, ImageToolbar ]
+			} )
+			.then( newEditor => {
+				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'foo', '|', 'imageTextAlternative' ] );
 
 				newEditor.destroy();
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added separators between `ImageTextAlternative` and `ImageStyle` plugin buttons in `ImageToolbar`. Closes ckeditor/ckeditor5#5072.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/160.
