### PR TITLE
Extracted nested editable styles and logic to widgets.

### DIFF
--- a/src/image/utils.js
+++ b/src/image/utils.js
@@ -7,7 +7,7 @@
  * @module image/image/utils
  */
 
-import { widgetize, isWidget } from '../widget/utils';
+import { toWidget, isWidget } from '../widget/utils';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 
 const imageSymbol = Symbol( 'isImage' );
@@ -15,7 +15,7 @@ const imageSymbol = Symbol( 'isImage' );
 /**
  * Converts given {@link module:engine/view/element~Element} to image widget:
  * * adds {@link module:engine/view/element~Element#setCustomProperty custom property} allowing to recognize image widget element,
- * * calls {@link module:image/widget/utils~widgetize widgetize} function with proper element's label creator.
+ * * calls {@link module:image/widget/utils~toWidget toWidget} function with proper element's label creator.
  *
  * @param {module:engine/view/element~Element} viewElement
  * @param {String} label Element's label. It will be concatenated with image's `alt` attribute if one is present.
@@ -24,7 +24,7 @@ const imageSymbol = Symbol( 'isImage' );
 export function toImageWidget( viewElement, label ) {
 	viewElement.setCustomProperty( imageSymbol, true );
 
-	return widgetize( viewElement, { label: labelCreator } );
+	return toWidget( viewElement, { label: labelCreator } );
 
 	function labelCreator() {
 		const imgElement = viewElement.getChild( 0 );

--- a/src/imagecaption/utils.js
+++ b/src/imagecaption/utils.js
@@ -8,7 +8,7 @@
  */
 
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
-import { createNestedEditable } from '../widget/utils';
+import { toWidgetEditable } from '../widget/utils';
 
 const captionSymbol = Symbol( 'imageCaption' );
 
@@ -20,7 +20,7 @@ const captionSymbol = Symbol( 'imageCaption' );
  */
 export function captionElementCreator( viewDocument ) {
 	return () => {
-		const editable = createNestedEditable( 'figcaption', viewDocument );
+		const editable = toWidgetEditable( 'figcaption', viewDocument );
 		editable.setCustomProperty( captionSymbol, true );
 
 		return editable;

--- a/src/imagecaption/utils.js
+++ b/src/imagecaption/utils.js
@@ -7,8 +7,8 @@
  * @module image/imagecaption/utils
  */
 
-import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
+import { createNestedEditable } from '../widget/utils';
 
 const captionSymbol = Symbol( 'imageCaption' );
 
@@ -20,17 +20,8 @@ const captionSymbol = Symbol( 'imageCaption' );
  */
 export function captionElementCreator( viewDocument ) {
 	return () => {
-		const editable = new ViewEditableElement( 'figcaption', { contenteditable: true } );
-		editable.document = viewDocument;
+		const editable = createNestedEditable( 'figcaption', viewDocument );
 		editable.setCustomProperty( captionSymbol, true );
-
-		editable.on( 'change:isFocused', ( evt, property, is ) => {
-			if ( is ) {
-				editable.addClass( 'focused' );
-			} else {
-				editable.removeClass( 'focused' );
-			}
-		} );
 
 		return editable;
 	};

--- a/src/imagecaption/utils.js
+++ b/src/imagecaption/utils.js
@@ -8,6 +8,7 @@
  */
 
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
+import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
 import { toWidgetEditable } from '../widget/utils';
 
 const captionSymbol = Symbol( 'imageCaption' );
@@ -20,10 +21,11 @@ const captionSymbol = Symbol( 'imageCaption' );
  */
 export function captionElementCreator( viewDocument ) {
 	return () => {
-		const editable = toWidgetEditable( 'figcaption', viewDocument );
+		const editable = new ViewEditableElement( 'figcaption' );
+		editable.document = viewDocument;
 		editable.setCustomProperty( captionSymbol, true );
 
-		return editable;
+		return toWidgetEditable( editable );
 	};
 }
 

--- a/src/widget/utils.js
+++ b/src/widget/utils.js
@@ -44,7 +44,7 @@ export function isWidget( element ) {
 }
 
 /**
- * "Widgetizes" given {@link module:engine/view/element~Element}:
+ * Converts given {@link module:engine/view/element~Element} to widget in following way:
  * * sets `contenteditable` attribute to `true`,
  * * adds custom `getFillerOffset` method returning `null`,
  * * adds `ck-widget` CSS class,
@@ -56,7 +56,7 @@ export function isWidget( element ) {
  * a plain string or a function returning a string.
  * @returns {module:engine/view/element~Element} Returns same element.
  */
-export function widgetize( element, options ) {
+export function toWidget( element, options ) {
 	options = options || {};
 	element.setAttribute( 'contenteditable', false );
 	element.getFillerOffset = getFillerOffset;
@@ -105,7 +105,7 @@ export function getLabel( element ) {
  * @param {module:engine/view/document~Document} viewDocument
  * @returns {module:engine/view/editableelement~EditableElement}
  */
-export function createNestedEditable( elementName, viewDocument ) {
+export function toWidgetEditable( elementName, viewDocument ) {
 	const editable = new ViewEditableElement( elementName, { contenteditable: true } );
 	editable.addClass( NESTED_EDITABLE_CLASS_NAME );
 	editable.document = viewDocument;

--- a/src/widget/utils.js
+++ b/src/widget/utils.js
@@ -20,13 +20,6 @@ const labelSymbol = Symbol( 'label' );
 export const WIDGET_CLASS_NAME = 'ck-widget';
 
 /**
- * CSS class added to each nested edtiable.
- *
- * @type {String}
- */
-export const NESTED_EDITABLE_CLASS_NAME = 'ck-nested-editable';
-
-/**
  * CSS class added to currently selected widget element.
  *
  * @const {String}
@@ -107,14 +100,14 @@ export function getLabel( element ) {
  */
 export function toWidgetEditable( elementName, viewDocument ) {
 	const editable = new ViewEditableElement( elementName, { contenteditable: true } );
-	editable.addClass( NESTED_EDITABLE_CLASS_NAME );
+	editable.addClass( 'ck-editable' );
 	editable.document = viewDocument;
 
 	editable.on( 'change:isFocused', ( evt, property, is ) => {
 		if ( is ) {
-			editable.addClass( 'focused' );
+			editable.addClass( 'ck-editable_focused' );
 		} else {
-			editable.removeClass( 'focused' );
+			editable.removeClass( 'ck-editable_focused' );
 		}
 	} );
 

--- a/src/widget/utils.js
+++ b/src/widget/utils.js
@@ -7,8 +7,6 @@
  * @module image/widget/utils
  */
 
-import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
-
 const widgetSymbol = Symbol( 'isWidget' );
 const labelSymbol = Symbol( 'label' );
 
@@ -92,16 +90,17 @@ export function getLabel( element ) {
 }
 
 /**
- * Creates nested editable element with proper CSS classes.
+ * Adds functionality to provided {module:engine/view/editableelement~EditableElement} to act as a widget's editable:
+ * * sets `contenteditable` attribute to `true`,
+ * * adds `ck-editable` CSS class,
+ * * adds `ck-editable_focused` CSS class when editable is focused and removes it when it's blurred.
  *
- * @param {String} elementName Name of the element to be created.
- * @param {module:engine/view/document~Document} viewDocument
- * @returns {module:engine/view/editableelement~EditableElement}
+ * @param {module:engine/view/editableelement~EditableElement} editable
+ * @returns {module:engine/view/editableelement~EditableElement} Returns same element that was provided in `editable` param.
  */
-export function toWidgetEditable( elementName, viewDocument ) {
-	const editable = new ViewEditableElement( elementName, { contenteditable: true } );
+export function toWidgetEditable( editable ) {
+	editable.setAttribute( 'contenteditable', 'true' );
 	editable.addClass( 'ck-editable' );
-	editable.document = viewDocument;
 
 	editable.on( 'change:isFocused', ( evt, property, is ) => {
 		if ( is ) {

--- a/src/widget/utils.js
+++ b/src/widget/utils.js
@@ -7,6 +7,8 @@
  * @module image/widget/utils
  */
 
+import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
+
 const widgetSymbol = Symbol( 'isWidget' );
 const labelSymbol = Symbol( 'label' );
 
@@ -16,6 +18,13 @@ const labelSymbol = Symbol( 'label' );
  * @const {String}
  */
 export const WIDGET_CLASS_NAME = 'ck-widget';
+
+/**
+ * CSS class added to each nested edtiable.
+ *
+ * @type {String}
+ */
+export const NESTED_EDITABLE_CLASS_NAME = 'ck-nested-editable';
 
 /**
  * CSS class added to currently selected widget element.
@@ -87,6 +96,29 @@ export function getLabel( element ) {
 	}
 
 	return typeof labelCreator == 'function' ? labelCreator() : labelCreator;
+}
+
+/**
+ * Creates nested editable element with proper CSS classes.
+ *
+ * @param {String} elementName Name of the element to be created.
+ * @param {module:engine/view/document~Document} viewDocument
+ * @returns {module:engine/view/editableelement~EditableElement}
+ */
+export function createNestedEditable( elementName, viewDocument ) {
+	const editable = new ViewEditableElement( elementName, { contenteditable: true } );
+	editable.addClass( NESTED_EDITABLE_CLASS_NAME );
+	editable.document = viewDocument;
+
+	editable.on( 'change:isFocused', ( evt, property, is ) => {
+		if ( is ) {
+			editable.addClass( 'focused' );
+		} else {
+			editable.removeClass( 'focused' );
+		}
+	} );
+
+	return editable;
 }
 
 // Default filler offset function applied to all widget elements.

--- a/src/widget/widget.js
+++ b/src/widget/widget.js
@@ -18,6 +18,8 @@ import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditabl
 import { isWidget } from './utils';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
+import '../../theme/widget/theme.scss';
+
 /**
  * The widget plugin.
  * Adds default {@link module:engine/view/document~Document#event:mousedown mousedown} handling on widget elements.

--- a/tests/imagecaption/imagecaptionengine.js
+++ b/tests/imagecaption/imagecaptionengine.js
@@ -101,7 +101,7 @@ describe( 'ImageCaptionEngine', () => {
 				expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
 					'<figure class="image ck-widget" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-nested-editable" contenteditable="true">Foo bar baz.</figcaption>' +
+						'<figcaption class="ck-editable" contenteditable="true">Foo bar baz.</figcaption>' +
 					'</figure>'
 				);
 			} );
@@ -214,7 +214,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar baz</figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true">foo bar baz</figcaption>' +
 				'</figure>'
 			);
 		} );
@@ -227,7 +227,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -248,7 +248,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar</figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true">foo bar</figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -277,7 +277,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true">[]</figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true">[]</figcaption>' +
 				'</figure>'
 			);
 		} );
@@ -294,7 +294,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -310,11 +310,11 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar</figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true">foo bar</figcaption>' +
 				'</figure>' +
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -346,7 +346,7 @@ describe( 'ImageCaptionEngine', () => {
 				expect( getViewData( viewDocument ) ).to.equal(
 					'<figure class="image ck-widget" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck-nested-editable" contenteditable="true">{foo bar baz}</figcaption>' +
+						'<figcaption class="ck-editable" contenteditable="true">{foo bar baz}</figcaption>' +
 					'</figure>'
 				);
 			} );

--- a/tests/imagecaption/imagecaptionengine.js
+++ b/tests/imagecaption/imagecaptionengine.js
@@ -101,7 +101,7 @@ describe( 'ImageCaptionEngine', () => {
 				expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
 					'<figure class="image ck-widget" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption contenteditable="true">Foo bar baz.</figcaption>' +
+						'<figcaption class="ck-nested-editable" contenteditable="true">Foo bar baz.</figcaption>' +
 					'</figure>'
 				);
 			} );
@@ -214,7 +214,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true">foo bar baz</figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar baz</figcaption>' +
 				'</figure>'
 			);
 		} );
@@ -227,7 +227,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -248,7 +248,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true">foo bar</figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar</figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -277,7 +277,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true">[]</figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true">[]</figcaption>' +
 				'</figure>'
 			);
 		} );
@@ -294,7 +294,7 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -310,11 +310,11 @@ describe( 'ImageCaptionEngine', () => {
 			expect( getViewData( viewDocument ) ).to.equal(
 				'<figure class="image ck-widget" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true">foo bar</figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true">foo bar</figcaption>' +
 				'</figure>' +
 				'[<figure class="image ck-widget ck-widget_selected" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption contenteditable="true"></figcaption>' +
+					'<figcaption class="ck-nested-editable" contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -346,7 +346,7 @@ describe( 'ImageCaptionEngine', () => {
 				expect( getViewData( viewDocument ) ).to.equal(
 					'<figure class="image ck-widget" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption contenteditable="true">{foo bar baz}</figcaption>' +
+						'<figcaption class="ck-nested-editable" contenteditable="true">{foo bar baz}</figcaption>' +
 					'</figure>'
 				);
 			} );

--- a/tests/imagecaption/utils.js
+++ b/tests/imagecaption/utils.js
@@ -29,18 +29,6 @@ describe( 'image captioning utils', () => {
 			expect( element.name ).to.equal( 'figcaption' );
 			expect( isCaption( element ) ).to.be.true;
 		} );
-
-		it( 'should be created in context of proper document', () => {
-			expect( element.document ).to.equal( document );
-		} );
-
-		it( 'should add proper class when element is focused', () => {
-			element.isFocused = true;
-			expect( element.hasClass( 'focused' ) ).to.be.true;
-
-			element.isFocused = false;
-			expect( element.hasClass( 'focused' ) ).to.be.false;
-		} );
 	} );
 
 	describe( 'isCaptionEditable', () => {

--- a/tests/widget/utils.js
+++ b/tests/widget/utils.js
@@ -6,11 +6,11 @@
 import ViewElement from '@ckeditor/ckeditor5-engine/src/view/element';
 import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import {
-	widgetize,
+	toWidget,
 	isWidget,
 	setLabel,
 	getLabel,
-	createNestedEditable,
+	toWidgetEditable,
 	WIDGET_CLASS_NAME,
 	NESTED_EDITABLE_CLASS_NAME
 } from '../../src/widget/utils';
@@ -20,10 +20,10 @@ describe( 'widget utils', () => {
 
 	beforeEach( () => {
 		element = new ViewElement( 'div' );
-		widgetize( element );
+		toWidget( element );
 	} );
 
-	describe( 'widgetize()', () => {
+	describe( 'toWidget()', () => {
 		it( 'should set contenteditable to false', () => {
 			expect( element.getAttribute( 'contenteditable' ) ).to.be.false;
 		} );
@@ -39,14 +39,14 @@ describe( 'widget utils', () => {
 
 		it( 'should add element\'s label if one is provided', () => {
 			element = new ViewElement( 'div' );
-			widgetize( element, { label: 'foo bar baz label' } );
+			toWidget( element, { label: 'foo bar baz label' } );
 
 			expect( getLabel( element ) ).to.equal( 'foo bar baz label' );
 		} );
 
 		it( 'should add element\'s label if one is provided as function', () => {
 			element = new ViewElement( 'div' );
-			widgetize( element, { label: () => 'foo bar baz label' } );
+			toWidget( element, { label: () => 'foo bar baz label' } );
 
 			expect( getLabel( element ) ).to.equal( 'foo bar baz label' );
 		} );
@@ -87,12 +87,12 @@ describe( 'widget utils', () => {
 		} );
 	} );
 
-	describe( 'createNestedEditable', () => {
+	describe( 'toWidgetEditable', () => {
 		let viewDocument, element;
 
 		beforeEach( () => {
 			viewDocument = new ViewDocument();
-			element = createNestedEditable( 'div', viewDocument );
+			element = toWidgetEditable( 'div', viewDocument );
 		} );
 
 		it( 'should be created in context of proper document', () => {

--- a/tests/widget/utils.js
+++ b/tests/widget/utils.js
@@ -4,7 +4,16 @@
  */
 
 import ViewElement from '@ckeditor/ckeditor5-engine/src/view/element';
-import { widgetize, isWidget, WIDGET_CLASS_NAME, setLabel, getLabel } from '../../src/widget/utils';
+import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
+import {
+	widgetize,
+	isWidget,
+	setLabel,
+	getLabel,
+	createNestedEditable,
+	WIDGET_CLASS_NAME,
+	NESTED_EDITABLE_CLASS_NAME
+} from '../../src/widget/utils';
 
 describe( 'widget utils', () => {
 	let element;
@@ -75,6 +84,31 @@ describe( 'widget utils', () => {
 			expect( getLabel( element ) ).to.equal( 'foo' );
 			caption = 'bar';
 			expect( getLabel( element ) ).to.equal( 'bar' );
+		} );
+	} );
+
+	describe( 'createNestedEditable', () => {
+		let viewDocument, element;
+
+		beforeEach( () => {
+			viewDocument = new ViewDocument();
+			element = createNestedEditable( 'div', viewDocument );
+		} );
+
+		it( 'should be created in context of proper document', () => {
+			expect( element.document ).to.equal( viewDocument );
+		} );
+
+		it( 'should add proper class', () => {
+			expect( element.hasClass( NESTED_EDITABLE_CLASS_NAME ) ).to.be.true;
+		} );
+
+		it( 'should add proper class when element is focused', () => {
+			element.isFocused = true;
+			expect( element.hasClass( 'focused' ) ).to.be.true;
+
+			element.isFocused = false;
+			expect( element.hasClass( 'focused' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/widget/utils.js
+++ b/tests/widget/utils.js
@@ -11,8 +11,7 @@ import {
 	setLabel,
 	getLabel,
 	toWidgetEditable,
-	WIDGET_CLASS_NAME,
-	NESTED_EDITABLE_CLASS_NAME
+	WIDGET_CLASS_NAME
 } from '../../src/widget/utils';
 
 describe( 'widget utils', () => {
@@ -100,15 +99,15 @@ describe( 'widget utils', () => {
 		} );
 
 		it( 'should add proper class', () => {
-			expect( element.hasClass( NESTED_EDITABLE_CLASS_NAME ) ).to.be.true;
+			expect( element.hasClass( 'ck-editable' ) ).to.be.true;
 		} );
 
 		it( 'should add proper class when element is focused', () => {
 			element.isFocused = true;
-			expect( element.hasClass( 'focused' ) ).to.be.true;
+			expect( element.hasClass( 'ck-editable_focused' ) ).to.be.true;
 
 			element.isFocused = false;
-			expect( element.hasClass( 'focused' ) ).to.be.false;
+			expect( element.hasClass( 'ck-editable_focused' ) ).to.be.false;
 		} );
 	} );
 } );

--- a/tests/widget/utils.js
+++ b/tests/widget/utils.js
@@ -4,6 +4,7 @@
  */
 
 import ViewElement from '@ckeditor/ckeditor5-engine/src/view/element';
+import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
 import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import {
 	toWidget,
@@ -91,7 +92,9 @@ describe( 'widget utils', () => {
 
 		beforeEach( () => {
 			viewDocument = new ViewDocument();
-			element = toWidgetEditable( 'div', viewDocument );
+			element = new ViewEditableElement( 'div' );
+			element.document = viewDocument;
+			toWidgetEditable( element );
 		} );
 
 		it( 'should be created in context of proper document', () => {

--- a/tests/widget/widget.js
+++ b/tests/widget/widget.js
@@ -7,7 +7,7 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import Widget from '../../src/widget/widget';
 import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobserver';
 import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
-import { widgetize } from '../../src/widget/utils';
+import { toWidget } from '../../src/widget/utils';
 import ViewContainer from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ViewEditable from '@ckeditor/ckeditor5-engine/src/view/editableelement';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
@@ -48,7 +48,7 @@ describe( 'Widget', () => {
 						const b = new AttributeContainer( 'b' );
 						const div = new ViewContainer( 'div', null, b );
 
-						return widgetize( div );
+						return toWidget( div );
 					} );
 
 				buildModelConverter().for( editor.editing.modelToView )

--- a/tests/widget/widgetengine.js
+++ b/tests/widget/widgetengine.js
@@ -10,7 +10,7 @@ import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-util
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import ViewContainer from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ViewEditable from '@ckeditor/ckeditor5-engine/src/view/editableelement';
-import { widgetize } from '../../src/widget/utils';
+import { toWidget } from '../../src/widget/utils';
 
 describe( 'WidgetEngine', () => {
 	let editor, document, viewDocument;
@@ -32,7 +32,7 @@ describe( 'WidgetEngine', () => {
 				buildModelConverter().for( editor.editing.modelToView )
 					.fromElement( 'widget' )
 					.toElement( () => {
-						const element = widgetize( new ViewContainer( 'div' ), { label: 'element label' } );
+						const element = toWidget( new ViewContainer( 'div' ), { label: 'element label' } );
 
 						return element;
 					} );

--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -2,27 +2,12 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_colors.scss';
-@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_shadow.scss';
-@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_states.scss';
 
 .ck-widget.image {
-	figcaption {
+	figcaption.ck-nested-editable {
 		background-color: ck-color( 'foreground' );
 		padding: 10px;
 		font-size: .8em;
 		color: ck-color( 'text', 40 );
-
-		// The `:focus` styles is applied before `.focused` class inside editables.
-		// These styles show different border for a blink of an eye.
-		&:focus {
-			outline: none;
-			box-shadow: none;
-		}
-
-		&.focused {
-			@include ck-focus-ring( 'outline' );
-			@include ck-box-shadow( $ck-inner-shadow );
-			background-color: ck-color( 'background' );;
-		}
 	}
 }

--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -4,7 +4,7 @@
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_colors.scss';
 
 .ck-widget.image {
-	figcaption.ck-nested-editable {
+	figcaption.ck-editable {
 		background-color: ck-color( 'foreground' );
 		padding: 10px;
 		font-size: .8em;

--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -6,12 +6,10 @@
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_fonts.scss';
 
 .ck-editor__editable {
-	.image {
-		.ck-editable {
-			background-color: ck-color( 'foreground' );
-			padding: ck-spacing();
-			font-size: ck-font-size( -1 );
-			color: ck-color( 'text', 40 );
-		}
+	.image > figcaption {
+		background-color: ck-color( 'foreground' );
+		padding: ck-spacing();
+		font-size: ck-font-size( -1 );
+		color: ck-color( 'text', 40 );
 	}
 }

--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -2,12 +2,14 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_colors.scss';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_spacing.scss';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_fonts.scss';
 
 .ck-widget.image {
-	figcaption.ck-editable {
+	.ck-editable {
 		background-color: ck-color( 'foreground' );
-		padding: 10px;
-		font-size: .8em;
+		padding: ck-spacing();
+		font-size: ck-font-size( -1 );
 		color: ck-color( 'text', 40 );
 	}
 }

--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -5,11 +5,13 @@
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_spacing.scss';
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_fonts.scss';
 
-.ck-widget.image {
-	.ck-editable {
-		background-color: ck-color( 'foreground' );
-		padding: ck-spacing();
-		font-size: ck-font-size( -1 );
-		color: ck-color( 'text', 40 );
+.ck-editor__editable {
+	.image {
+		.ck-editable {
+			background-color: ck-color( 'foreground' );
+			padding: ck-spacing();
+			font-size: ck-font-size( -1 );
+			color: ck-color( 'text', 40 );
+		}
 	}
 }

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -1,7 +1,6 @@
 // Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
-// Image widget's styles.
 .ck-editor__editable {
 	.image {
 		text-align: center;

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -2,24 +2,26 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 // Image widget's styles.
-.image {
-	text-align: center;
-	clear: both;
+.ck-editor__editable {
+	.image {
+		text-align: center;
+		clear: both;
 
-	&.image-style-side {
-		float: right;
-		margin-left: 0.8em;
-		max-width: 50%;
+		&.image-style-side {
+			float: right;
+			margin-left: 0.8em;
+			max-width: 50%;
+		}
 	}
-}
 
-.image > img {
-	// Prevent unnecessary margins caused by line-height (see #44).
-	display: block;
+	.image > img {
+		// Prevent unnecessary margins caused by line-height (see #44).
+		display: block;
 
-	// Center the image if its width is smaller than content's width.
-	margin: 0 auto;
+		// Center the image if its width is smaller than content's width.
+		margin: 0 auto;
 
-	// Make sure the image never exceeds the size of the parent container (#67).
-	max-width: 100%;
+		// Make sure the image never exceeds the size of the parent container (#67).
+		max-width: 100%;
+	}
 }

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -1,24 +1,6 @@
 // Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
-// Common styles applied to all widgets.
-.ck-widget {
-	margin: 10px 0;
-	padding: 0;
-
-	&.ck-widget_selected, &.ck-widget_selected:hover {
-		outline: 2px solid #ace;
-	}
-
-	.ck-editor__editable.ck-blurred &.ck-widget_selected {
-		outline: 2px solid #ddd;
-	}
-
-	&:hover {
-		outline: 2px solid yellow;
-	}
-}
-
 // Image widget's styles.
 .image {
 	text-align: center;

--- a/theme/widget/theme.scss
+++ b/theme/widget/theme.scss
@@ -21,18 +21,17 @@
 		outline: 2px solid yellow;
 	}
 
-	.ck-nested-editable {
+	.ck-editable {
 		// The `:focus` styles is applied before `.focused` class inside editables.
 		// These styles show different border for a blink of an eye.
 		&:focus {
+			&.ck-editable_focused {
+				@include ck-focus-ring( 'outline' );
+				@include ck-box-shadow( $ck-inner-shadow );
+				background-color: ck-color( 'background' );;
+			}
 			outline: none;
 			box-shadow: none;
-		}
-
-		&.focused {
-			@include ck-focus-ring( 'outline' );
-			@include ck-box-shadow( $ck-inner-shadow );
-			background-color: ck-color( 'background' );;
 		}
 	}
 }

--- a/theme/widget/theme.scss
+++ b/theme/widget/theme.scss
@@ -29,13 +29,13 @@ $widget-outline-thickness: 2px;
 		outline: $widget-outline-thickness solid ck-color( 'widget-hover' );
 	}
 
-.ck-editable {
-	// The `:focus` style is applied before `.ck-editable_focused` class is rendered in the view.
-	// These styles show a different border for a blink of an eye, so `:focus` need to have same styles applied.
-	&.ck-editable_focused, &:focus {
-		@include ck-focus-ring( 'outline' );
-		@include ck-box-shadow( $ck-inner-shadow );
-		background-color: ck-color( 'background' );
+	.ck-editable {
+		// The `:focus` style is applied before `.ck-editable_focused` class is rendered in the view.
+		// These styles show a different border for a blink of an eye, so `:focus` need to have same styles applied.
+		&.ck-editable_focused, &:focus {
+			@include ck-focus-ring( 'outline' );
+			@include ck-box-shadow( $ck-inner-shadow );
+			background-color: ck-color( 'background' );
+		}
 	}
-}
 }

--- a/theme/widget/theme.scss
+++ b/theme/widget/theme.scss
@@ -4,34 +4,38 @@
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_colors.scss';
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_shadow.scss';
 @import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_states.scss';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_spacing.scss';
+
+@include ck-color-add( (
+	'widget-blurred': #ddd,
+	'widget-hover': yellow
+) );
+
+$widget-outline-thickness: 2px;
 
 .ck-widget {
-	margin: 10px 0;
+	margin: ck-spacing() 0;
 	padding: 0;
 
 	&.ck-widget_selected, &.ck-widget_selected:hover {
-		outline: 2px solid #ace;
+		outline: $widget-outline-thickness solid ck-color( 'focus' );
 	}
 
 	.ck-editor__editable.ck-blurred &.ck-widget_selected {
-		outline: 2px solid #ddd;
+		outline: $widget-outline-thickness solid ck-color( 'widget-blurred' );
 	}
 
 	&:hover {
-		outline: 2px solid yellow;
+		outline: $widget-outline-thickness solid ck-color( 'widget-hover' );
 	}
 
-	.ck-editable {
-		// The `:focus` styles is applied before `.focused` class inside editables.
-		// These styles show different border for a blink of an eye.
-		&:focus {
-			&.ck-editable_focused {
-				@include ck-focus-ring( 'outline' );
-				@include ck-box-shadow( $ck-inner-shadow );
-				background-color: ck-color( 'background' );;
-			}
-			outline: none;
-			box-shadow: none;
-		}
+.ck-editable {
+	// The `:focus` style is applied before `.ck-editable_focused` class is rendered in the view.
+	// These styles show a different border for a blink of an eye, so `:focus` need to have same styles applied.
+	&.ck-editable_focused, &:focus {
+		@include ck-focus-ring( 'outline' );
+		@include ck-box-shadow( $ck-inner-shadow );
+		background-color: ck-color( 'background' );
 	}
+}
 }

--- a/theme/widget/theme.scss
+++ b/theme/widget/theme.scss
@@ -1,0 +1,38 @@
+// Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+// For licensing, see LICENSE.md or http://ckeditor.com/license
+
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_colors.scss';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_shadow.scss';
+@import '~@ckeditor/ckeditor5-theme-lark/theme/helpers/_states.scss';
+
+.ck-widget {
+	margin: 10px 0;
+	padding: 0;
+
+	&.ck-widget_selected, &.ck-widget_selected:hover {
+		outline: 2px solid #ace;
+	}
+
+	.ck-editor__editable.ck-blurred &.ck-widget_selected {
+		outline: 2px solid #ddd;
+	}
+
+	&:hover {
+		outline: 2px solid yellow;
+	}
+
+	.ck-nested-editable {
+		// The `:focus` styles is applied before `.focused` class inside editables.
+		// These styles show different border for a blink of an eye.
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
+
+		&.focused {
+			@include ck-focus-ring( 'outline' );
+			@include ck-box-shadow( $ck-inner-shadow );
+			background-color: ck-color( 'background' );;
+		}
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Nested editables have own CSS classes and their creation utility is extracted to widgets. Closes ckeditor/ckeditor5#5067.

BREAKING CHANGE: Widget utility function `widgetize` is renamed to `toWidget`.