### PR TITLE
T/78 Prevent adding caption to image twice

### DIFF
--- a/src/imagecaption/imagecaptionengine.js
+++ b/src/imagecaption/imagecaptionengine.js
@@ -139,7 +139,11 @@ function insertMissingModelCaptionElement( evt, changeType, data, batch ) {
 
 		if ( value.type == 'elementStart' && isImage( item ) && !getCaptionFromImage( item ) ) {
 			batch.document.enqueueChanges( () => {
-				batch.insert( ModelPosition.createAt( item, 'end' ), new ModelElement( 'caption' ) );
+				// Make sure that the image does not have caption already.
+				// https://github.com/ckeditor/ckeditor5-image/issues/78
+				if ( !getCaptionFromImage( item ) ) {
+					batch.insert( ModelPosition.createAt( item, 'end' ), new ModelElement( 'caption' ) );
+				}
 			} );
 		}
 	}

--- a/tests/imagecaption/imagecaptionengine.js
+++ b/tests/imagecaption/imagecaptionengine.js
@@ -248,17 +248,15 @@ describe( 'ImageCaptionEngine', () => {
 			const caption = new ModelElement( 'caption' );
 			const batch = document.batch();
 
-			// When first change to the document will be made - manually add caption to the image element.
-			document.once( 'change', () => {
-				document.enqueueChanges( () => {
-					batch.insert( ModelPosition.createAt( image ), caption );
-				} );
-			}, { priority: 'high' } );
-
 			document.enqueueChanges( () => {
-				batch.insert( ModelPosition.createAt( document.getRoot() ), image );
+				batch
+					// Since we are adding an empty image, this should trigger caption fixer.
+					.insert( ModelPosition.createAt( document.getRoot() ), image )
+					// Add caption just after the image is inserted, in same batch and enqueue changes block.
+					.insert( ModelPosition.createAt( image ), caption );
 			} );
 
+			// Check whether caption fixer added redundant caption.
 			expect( getModelData( document ) ).to.equal(
 				'[]<image alt="" src=""><caption></caption></image>'
 			);

--- a/tests/imagecaption/imagecaptionengine.js
+++ b/tests/imagecaption/imagecaptionengine.js
@@ -189,6 +189,34 @@ describe( 'ImageCaptionEngine', () => {
 			);
 		} );
 
+		it( 'should not add caption element twice', () => {
+			const image = new ModelElement( 'image', { src: '', alt: '' } );
+			const caption = new ModelElement( 'caption' );
+			const batch = document.batch();
+
+			// When first change to the document will be made - manually add caption to the image element.
+			document.once( 'change', () => {
+				document.enqueueChanges( () => {
+					batch.insert( ModelPosition.createAt( image ), caption );
+				} );
+			}, { priority: 'high' } );
+
+			document.enqueueChanges( () => {
+				batch.insert( ModelPosition.createAt( document.getRoot() ), image );
+			} );
+
+			expect( getModelData( document ) ).to.equal(
+				'[]<image alt="" src=""><caption></caption></image>'
+			);
+
+			expect( getViewData( viewDocument ) ).to.equal(
+				'[]<figure class="image ck-widget" contenteditable="false">' +
+				'<img alt="" src=""></img>' +
+				'<figcaption class="ck-editable ck-hidden" contenteditable="true"></figcaption>' +
+				'</figure>'
+			);
+		} );
+
 		it( 'should do nothing for other changes than insert', () => {
 			setModelData( document, '<image src=""><caption>foo bar</caption></image>' );
 			const image = document.getRoot().getChild( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Caption will not be automatically added second time if it was already added before "caption fixer" got fired. Closes ckeditor/ckeditor5#5082.

---

### Additional information
Please close after: https://github.com/ckeditor/ckeditor5-image/pull/81
