### PR TITLE
Improved visual styles of the image widget

### DIFF
--- a/theme/imagecaption/theme.scss
+++ b/theme/imagecaption/theme.scss
@@ -11,5 +11,6 @@
 		padding: ck-spacing();
 		font-size: ck-font-size( -1 );
 		color: ck-color( 'text', 40 );
+		outline-offset: -1px;
 	}
 }

--- a/theme/widget/theme.scss
+++ b/theme/widget/theme.scss
@@ -8,10 +8,10 @@
 
 @include ck-color-add( (
 	'widget-blurred': #ddd,
-	'widget-hover': yellow
+	'widget-hover': #FFD25C
 ) );
 
-$widget-outline-thickness: 2px;
+$widget-outline-thickness: 3px;
 
 .ck-widget {
 	margin: ck-spacing() 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved visual styles of the image widget . Closes ckeditor/ckeditor5#5036.

---

### Additional information
I've created two versions.
First version (on this branch) copies styles from https://ckeditor5.github.io/ (bigger outline over image, and new color on hovering):
![ver1](https://cloud.githubusercontent.com/assets/2396463/24507472/d65a159c-1560-11e7-94ac-9e90614c8e3b.gif)
____
Second version (on [t/12a branch](https://github.com/ckeditor/ckeditor5-image/tree/t/12a)) tries to get close to things proposed by @oleq in ckeditor/ckeditor5#5036 (no rounded borders because CSS outline doesn't suport that - if we really want it we should start using border-color on focus): 
![ver2](https://cloud.githubusercontent.com/assets/2396463/24507646/50eb9b46-1561-11e7-83a6-54786d24067e.gif)
