### PR TITLE
Changed: `caption` in schema now inherits from `$block`.

### DIFF
--- a/src/imagecaption/imagecaptionengine.js
+++ b/src/imagecaption/imagecaptionengine.js
@@ -61,7 +61,7 @@ export default class ImageCaptionEngine extends Plugin {
 		this._createCaption = captionElementCreator( viewDocument, t( 'Enter image caption' ) );
 
 		// Schema configuration.
-		schema.registerItem( 'caption' );
+		schema.registerItem( 'caption', '$block' );
 		schema.allow( { name: '$inline', inside: 'caption' } );
 		schema.allow( { name: 'caption', inside: 'image' } );
 		schema.limits.add( 'caption' );

--- a/tests/imagecaption/imagecaptionengine.js
+++ b/tests/imagecaption/imagecaptionengine.js
@@ -46,6 +46,7 @@ describe( 'ImageCaptionEngine', () => {
 	it( 'should set proper schema rules', () => {
 		expect( document.schema.check( { name: 'caption', iniside: 'image' } ) ).to.be.true;
 		expect( document.schema.check( { name: '$inline', inside: 'caption' } ) ).to.be.true;
+		expect( document.schema.itemExtends( 'caption', '$block' ) ).to.be.true;
 		expect( document.schema.limits.has( 'caption' ) );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Schema item `caption` now inherits from schema item `$block`. Closes ckeditor/ckeditor5#5089.