### PR TITLE
Introduced standalone view-to-model converter for img element.

### DIFF
--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -19,6 +19,9 @@ import modelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
  *
  *		<image src="..." alt="..."></image>
  *
+ * The entire contents of `<figure>` except the first `<img>` is being converted as children
+ * of the `<image>` model element.
+ *
  * @returns {Function}
  */
 export function viewFigureToModel() {
@@ -34,7 +37,7 @@ export function viewFigureToModel() {
 		}
 
 		// Find an image element inside the figure element.
-		const viewImage = Array.from( data.input.getChildren() ).find( ( viewChild ) => viewChild.is( 'img' ) );
+		const viewImage = Array.from( data.input.getChildren() ).find( viewChild => viewChild.is( 'img' ) );
 
 		// Do not convert if image element is absent, is missing src attribute or was already converted.
 		if ( !viewImage || !viewImage.hasAttribute( 'src' ) || !consumable.test( viewImage, { name: true } ) ) {

--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -7,7 +7,6 @@
  * @module image/image/converters
  */
 
-import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 import modelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
 
@@ -22,50 +21,41 @@ import modelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
  *
  * @returns {Function}
  */
-export function viewToModelImage() {
+export function viewFigureToModel() {
 	return ( evt, data, consumable, conversionApi ) => {
-		const viewFigureElement = data.input;
-
-		// *** Step 1: Validate conversion.
-		// Check if figure element can be consumed.
-		if ( !consumable.test( viewFigureElement, { name: true, class: 'image' } ) ) {
+		// Do not convert if this is not an "image figure".
+		if ( !consumable.test( data.input, { name: true, class: 'image' } ) ) {
 			return;
 		}
 
-		// Check if image element can be converted in current context.
+		// Do not convert if image cannot be placed in model at this context.
 		if ( !conversionApi.schema.check( { name: 'image', inside: data.context, attributes: 'src' } ) ) {
 			return;
 		}
 
-		// Check if img element is placed inside figure element and can be consumed with `src` attribute.
-		const viewImg = viewFigureElement.getChild( 0 );
+		// Find an image element inside the figure element.
+		const viewImage = Array.from( data.input.getChildren() ).find( ( viewChild ) => viewChild.is( 'img' ) );
 
-		if ( !viewImg || viewImg.name != 'img' || !consumable.test( viewImg, { name: true, attribute: 'src' } ) ) {
+		// Do not convert if image element is absent, is missing src attribute or was already converted.
+		if ( !viewImage || !viewImage.hasAttribute( 'src' ) || !consumable.test( viewImage, { name: true } ) ) {
 			return;
 		}
 
-		// *** Step2: Convert to model.
-		consumable.consume( viewFigureElement, { name: true, class: 'image' } );
-		consumable.consume( viewImg, { name: true, attribute: 'src' } );
+		// Convert view image to model image.
+		const modelImage = conversionApi.convertItem( viewImage, consumable, data );
 
-		// Create model element.
-		const modelImage = new ModelElement( 'image', {
-			src: viewImg.getAttribute( 'src' )
-		} );
-
-		// Convert `alt` attribute if present.
-		if ( consumable.consume( viewImg, { attribute: [ 'alt' ] } ) ) {
-			modelImage.setAttribute( 'alt', viewImg.getAttribute( 'alt' ) );
-		}
-
-		// Convert children of converted view element and append them to `modelImage`.
-		// TODO https://github.com/ckeditor/ckeditor5-engine/issues/736.
+		// Convert rest of figure element's children, but in the context of model image, because those converted
+		// children will be added as model image children.
 		data.context.push( modelImage );
-		const modelChildren = conversionApi.convertChildren( viewFigureElement, consumable, data );
-		const insertPosition = ModelPosition.createAt( modelImage, 'end' );
-		modelWriter.insert( insertPosition, modelChildren );
+
+		const modelChildren = conversionApi.convertChildren( data.input, consumable, data );
+
 		data.context.pop();
 
+		// Add converted children to model image.
+		modelWriter.insert( ModelPosition.createAt( modelImage ), modelChildren );
+
+		// Set model image as conversion result.
 		data.output = modelImage;
 	};
 }

--- a/src/image/imageengine.js
+++ b/src/image/imageengine.js
@@ -9,8 +9,10 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import buildModelConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildmodelconverter';
-import { viewToModelImage, createImageAttributeConverter } from './converters';
+import buildViewConverter from '@ckeditor/ckeditor5-engine/src/conversion/buildviewconverter';
+import { viewFigureToModel, createImageAttributeConverter } from './converters';
 import { toImageWidget } from './utils';
+import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import ViewContainerElement from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ViewEmptyElement from '@ckeditor/ckeditor5-engine/src/view/emptyelement';
 
@@ -52,8 +54,18 @@ export default class ImageEngine extends Plugin {
 		createImageAttributeConverter( [ editing.modelToView, data.modelToView ], 'src' );
 		createImageAttributeConverter( [ editing.modelToView, data.modelToView ], 'alt' );
 
+		// Build converter for view img element to model image element.
+		buildViewConverter().for( data.viewToModel )
+			.from( { name: 'img', attribute: { src: /.+/ } } )
+			.toElement( ( viewImage ) => new ModelElement( 'image', { src: viewImage.getAttribute( 'src' ) } ) );
+
+		// Build converter for alt attribute.
+		buildViewConverter().for( data.viewToModel )
+			.fromAttribute( 'alt' )
+			.toAttribute( 'alt' );
+
 		// Converter for figure element from view to model.
-		data.viewToModel.on( 'element:figure', viewToModelImage() );
+		data.viewToModel.on( 'element:figure', viewFigureToModel() );
 	}
 }
 

--- a/src/image/imageengine.js
+++ b/src/image/imageengine.js
@@ -57,12 +57,13 @@ export default class ImageEngine extends Plugin {
 		// Build converter for view img element to model image element.
 		buildViewConverter().for( data.viewToModel )
 			.from( { name: 'img', attribute: { src: /./ } } )
-			.toElement( viewImage => new ModelElement( 'image', { src: viewImage.getAttribute( 'src' ) } ) );
+			.toElement( ( viewImage ) => new ModelElement( 'image', { src: viewImage.getAttribute( 'src' ) } ) );
 
 		// Build converter for alt attribute.
 		buildViewConverter().for( data.viewToModel )
-			.fromAttribute( 'alt' )
-			.toAttribute( 'alt' );
+			.from( { name: 'img', attribute: { alt: /./ } } )
+			.consuming( { attribute: [ 'alt' ] } )
+			.toAttribute( ( viewImage ) => ( { key: 'alt', value: viewImage.getAttribute( 'alt' ) } ) );
 
 		// Converter for figure element from view to model.
 		data.viewToModel.on( 'element:figure', viewFigureToModel() );

--- a/src/image/imageengine.js
+++ b/src/image/imageengine.js
@@ -56,8 +56,8 @@ export default class ImageEngine extends Plugin {
 
 		// Build converter for view img element to model image element.
 		buildViewConverter().for( data.viewToModel )
-			.from( { name: 'img', attribute: { src: /.+/ } } )
-			.toElement( ( viewImage ) => new ModelElement( 'image', { src: viewImage.getAttribute( 'src' ) } ) );
+			.from( { name: 'img', attribute: { src: /./ } } )
+			.toElement( viewImage => new ModelElement( 'image', { src: viewImage.getAttribute( 'src' ) } ) );
 
 		// Build converter for alt attribute.
 		buildViewConverter().for( data.viewToModel )

--- a/tests/image/imageengine.js
+++ b/tests/image/imageengine.js
@@ -153,6 +153,7 @@ describe( 'ImageEngine', () => {
 				const editing = editor.editing;
 
 				document.schema.registerItem( 'div', '$block' );
+				document.schema.allow( { name: 'div', attributes: 'alt', inside: '$root' } );
 
 				buildModelConverter().for( data.modelToView, editing.modelToView ).fromElement( 'div' ).toElement( 'div' );
 				buildViewConverter().for( data.viewToModel ).fromElement( 'div' ).toElement( 'div' );

--- a/tests/image/imageengine.js
+++ b/tests/image/imageengine.js
@@ -58,7 +58,7 @@ describe( 'ImageEngine', () => {
 			} );
 
 			it( 'should not convert if there is no image class', () => {
-				editor.setData( '<figure><img src="foo.png" alt="alt text" /></figure>' );
+				editor.setData( '<figure class="quote">My quote</figure>' );
 
 				expect( getModelData( document, { withoutSelection: true } ) )
 					.to.equal( '' );
@@ -139,6 +139,13 @@ describe( 'ImageEngine', () => {
 				editor.setData( '<figure class="image"><img src="foo.png" alt="alt text" /><figcaption></figcaption></figure>' );
 
 				sinon.assert.calledOnce( conversionSpy );
+			} );
+
+			it( 'should convert bare img element', () => {
+				editor.setData( '<img src="foo.png" alt="alt text" />' );
+
+				expect( getModelData( document, { withoutSelection: true } ) )
+					.to.equal( '<image alt="alt text" src="foo.png"></image>' );
 			} );
 		} );
 	} );

--- a/tests/image/imageengine.js
+++ b/tests/image/imageengine.js
@@ -147,6 +147,28 @@ describe( 'ImageEngine', () => {
 				expect( getModelData( document, { withoutSelection: true } ) )
 					.to.equal( '<image alt="alt text" src="foo.png"></image>' );
 			} );
+
+			it( 'should not convert alt attribute on non-img element', () => {
+				const data = editor.data;
+				const editing = editor.editing;
+
+				document.schema.registerItem( 'div', '$block' );
+
+				buildModelConverter().for( data.modelToView, editing.modelToView ).fromElement( 'div' ).toElement( 'div' );
+				buildViewConverter().for( data.viewToModel ).fromElement( 'div' ).toElement( 'div' );
+
+				editor.setData( '<div alt="foo"></div>' );
+
+				expect( getModelData( document, { withoutSelection: true } ) ).to.equal( '<div></div>' );
+			} );
+
+			it( 'should handle figure with two images', () => {
+				document.schema.allow( { name: '$text', inside: 'image' } );
+
+				editor.setData( '<figure class="image"><img src="foo.jpg" /><img src="bar.jpg" />abc</figure>' );
+
+				expect( getModelData( document, { withoutSelection: true } ) ).to.equal( '<image src="foo.jpg">abc</image>' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced view-to-model conversion for bare `<img>` elements. Closes ckeditor/ckeditor5#5032.