### PR TITLE
t/60: Removed config.image.defaultToolbar

### DIFF
--- a/src/imagestyle.js
+++ b/src/imagestyle.js
@@ -42,17 +42,6 @@ export default class ImageStyle extends Plugin {
 		for ( let style of styles ) {
 			this._createButton( style );
 		}
-
-		// Push buttons to default image toolbar if one exists.
-		const defaultImageToolbarConfig = this.editor.config.get( 'image.defaultToolbar' );
-
-		if ( defaultImageToolbarConfig ) {
-			if ( defaultImageToolbarConfig.length ) {
-				defaultImageToolbarConfig.push( '|' );
-			}
-
-			styles.forEach( style => defaultImageToolbarConfig.push( style.name ) );
-		}
 	}
 
 	/**

--- a/src/imagetextalternative.js
+++ b/src/imagetextalternative.js
@@ -45,17 +45,6 @@ export default class ImageTextAlternative extends Plugin {
 	init() {
 		this._createButton();
 
-		// Push button to default image toolbar if the image toolbar was loaded.
-		const defaultImageToolbarConfig = this.editor.config.get( 'image.defaultToolbar' );
-
-		if ( defaultImageToolbarConfig ) {
-			if ( defaultImageToolbarConfig.length ) {
-				defaultImageToolbarConfig.push( '|' );
-			}
-
-			defaultImageToolbarConfig.push( 'imageTextAlternative' );
-		}
-
 		return this._createBalloonPanel().then( panel => {
 			/**
 			 * Balloon panel containing text alternative change form.

--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -17,8 +17,6 @@ import ImageBalloonPanel from './image/ui/imageballoonpanelview';
  * Image toolbar class. Creates image toolbar placed inside balloon panel that is showed when image widget is selected.
  * Toolbar components are created using editor's {@link module:ui/componentfactory~ComponentFactory ComponentFactory}
  * based on {@link module:core/editor/editor~Editor#config configuration} stored under `image.toolbar`.
- * Other plugins can add new components to the default toolbar configuration by pushing them to `image.defaultToolbar`
- * configuration. Default configuration is used when `image.toolbar` config is not present.
  *
  * @extends module:core/plugin~Plugin
  */
@@ -36,8 +34,6 @@ export default class ImageToolbar extends Plugin {
 	constructor( editor ) {
 		super( editor );
 
-		editor.config.set( 'image.defaultToolbar', [] );
-
 		/**
 		 * When set to `true`, toolbar will be repositioned and showed on each render event and focus change.
 		 * Set to `false` to temporary disable the image toolbar.
@@ -52,10 +48,10 @@ export default class ImageToolbar extends Plugin {
 	 */
 	afterInit() {
 		const editor = this.editor;
-		const toolbarConfig = editor.config.get( 'image.toolbar' ) || editor.config.get( 'image.defaultToolbar' );
+		const toolbarConfig = editor.config.get( 'image.toolbar' );
 
 		// Don't add the toolbar if there is no configuration.
-		if ( !toolbarConfig.length ) {
+		if ( !toolbarConfig || !toolbarConfig.length ) {
 			return;
 		}
 

--- a/tests/imagestyle.js
+++ b/tests/imagestyle.js
@@ -3,9 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
-import ImageToolbar from '../src/imagetoolbar';
 import ImageStyle from '../src/imagestyle';
 import ImageStyleEngine from '../src/imagestyle/imagestyleengine';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
@@ -67,46 +65,6 @@ describe( 'ImageStyle', () => {
 
 			spy.reset();
 		}
-	} );
-
-	it( 'should not add buttons to default image toolbar if image toolbar is not present', () => {
-		expect( editor.config.get( 'image.defaultToolbar' ) ).to.be.undefined;
-	} );
-
-	it( 'should add buttons to default image toolbar if toolbar is present', () => {
-		const editorElement = global.document.createElement( 'div' );
-		global.document.body.appendChild( editorElement );
-
-		return ClassicTestEditor.create( editorElement, {
-			plugins: [ ImageStyle, ImageToolbar ]
-		} )
-			.then( newEditor => {
-				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'imageStyleFull', 'imageStyleSide' ] );
-
-				newEditor.destroy();
-			} );
-	} );
-
-	it( 'should add separator before the button if toolbar is present and already has items', () => {
-		const editorElement = global.document.createElement( 'div' );
-		global.document.body.appendChild( editorElement );
-
-		const FooPlugin = class extends Plugin {
-			init() {
-				this.editor.ui.componentFactory.add( 'foo', () => new ButtonView() );
-
-				this.editor.config.get( 'image.defaultToolbar' ).push( 'foo' );
-			}
-		};
-
-		return ClassicTestEditor.create( editorElement, {
-			plugins: [ FooPlugin, ImageStyle, ImageToolbar ]
-		} )
-		.then( newEditor => {
-			expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'foo', '|', 'imageStyleFull', 'imageStyleSide' ] );
-
-			newEditor.destroy();
-		} );
 	} );
 
 	it( 'should not add buttons to image toolbar if configuration is present', () => {

--- a/tests/imagetextalternative.js
+++ b/tests/imagetextalternative.js
@@ -3,7 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Image from '../src/image';
 import ImageToolbar from '../src/imagetoolbar';
@@ -91,46 +90,6 @@ describe( 'ImageTextAlternative', () => {
 
 			sinon.assert.calledOnce( spy );
 			expect( plugin.form.lebeledInput.value ).equals( '' );
-		} );
-
-		it( 'should not add button to default image toolbar if image toolbar is not present', () => {
-			expect( editor.config.get( 'image.defaultToolbar' ) ).to.be.undefined;
-		} );
-
-		it( 'should add button to default image toolbar if toolbar is present', () => {
-			const editorElement = global.document.createElement( 'div' );
-			global.document.body.appendChild( editorElement );
-
-			return ClassicTestEditor.create( editorElement, {
-				plugins: [ ImageTextAlternative, ImageToolbar ]
-			} )
-			.then( newEditor => {
-				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'imageTextAlternative' ] );
-
-				newEditor.destroy();
-			} );
-		} );
-
-		it( 'should add separator before the button if toolbar is present and already has items', () => {
-			const editorElement = global.document.createElement( 'div' );
-			global.document.body.appendChild( editorElement );
-
-			const FooPlugin = class extends Plugin {
-				init() {
-					this.editor.ui.componentFactory.add( 'foo', () => new ButtonView() );
-
-					this.editor.config.get( 'image.defaultToolbar' ).push( 'foo' );
-				}
-			};
-
-			return ClassicTestEditor.create( editorElement, {
-				plugins: [ FooPlugin, ImageTextAlternative, ImageToolbar ]
-			} )
-			.then( newEditor => {
-				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'foo', '|', 'imageTextAlternative' ] );
-
-				newEditor.destroy();
-			} );
 		} );
 	} );
 

--- a/tests/imagetoolbar.js
+++ b/tests/imagetoolbar.js
@@ -42,20 +42,6 @@ describe( 'ImageToolbar', () => {
 		expect( editor.plugins.get( ImageToolbar ) ).to.be.instanceOf( ImageToolbar );
 	} );
 
-	it( 'should initialize image.defaultToolbar to an empty array', () => {
-		const editorElement = global.document.createElement( 'div' );
-		global.document.body.appendChild( editorElement );
-
-		return ClassicEditor.create( editorElement, {
-			plugins: [ ImageToolbar ],
-		} )
-		.then( editor => {
-			expect( editor.config.get( 'image.defaultToolbar' ) ).to.eql( [] );
-
-			return editor.destroy();
-		} );
-	} );
-
 	it( 'should not initialize if there is no configuration', () => {
 		const editorElement = global.document.createElement( 'div' );
 		global.document.body.appendChild( editorElement );
@@ -65,25 +51,6 @@ describe( 'ImageToolbar', () => {
 		} )
 			.then( newEditor => {
 				expect( newEditor.plugins.get( ImageToolbar )._panel ).to.be.undefined;
-
-				newEditor.destroy();
-			} );
-	} );
-
-	it( 'should allow other plugins to alter default config', () => {
-		const editorElement = global.document.createElement( 'div' );
-		global.document.body.appendChild( editorElement );
-
-		return ClassicEditor.create( editorElement, {
-			plugins: [ ImageToolbar, FakeButton, AlterDefaultConfig ]
-		} )
-			.then( newEditor => {
-				const panel = newEditor.plugins.get( ImageToolbar )._panel;
-				const toolbar = panel.content.get( 0 );
-				const button = toolbar.items.get( 0 );
-
-				expect( newEditor.config.get( 'image.defaultToolbar' ) ).to.eql( [ 'fake_button' ] );
-				expect( button.label ).to.equal( 'fake button' );
 
 				newEditor.destroy();
 			} );
@@ -143,16 +110,6 @@ describe( 'ImageToolbar', () => {
 
 				return view;
 			} );
-		}
-	}
-
-	class AlterDefaultConfig extends Plugin {
-		init() {
-			const defaultImageToolbarConfig = this.editor.config.get( 'image.defaultToolbar' );
-
-			if ( defaultImageToolbarConfig ) {
-				defaultImageToolbarConfig.push( 'fake_button' );
-			}
 		}
 	}
 } );

--- a/tests/manual/caption.js
+++ b/tests/manual/caption.js
@@ -25,7 +25,10 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 		Enter, Typing, Paragraph, Heading, Image, ImageToolbar,
 		Undo, Clipboard, ImageCaption, ImageStyle, Bold, Italic, Heading, List
 	],
-	toolbar: [ 'headings', 'undo', 'redo', 'bold', 'italic', 'bulletedList', 'numberedList' ]
+	toolbar: [ 'headings', 'undo', 'redo', 'bold', 'italic', 'bulletedList', 'numberedList' ],
+	image: {
+		toolbar: [ 'imageStyleFull', 'imageStyleSide', '|' , 'imageTextAlternative' ]
+	}
 } )
 .then( editor => {
 	window.editor = editor;

--- a/tests/manual/imagestyle.js
+++ b/tests/manual/imagestyle.js
@@ -18,7 +18,10 @@ import ImageToolbar from '../../src/imagetoolbar';
 
 ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ ImageToolbar, EnterPlugin, TypingPlugin, ParagraphPlugin, HeadingPlugin, ImagePlugin, UndoPlugin, ClipboardPlugin, ImageStyle ],
-	toolbar: [ 'headings', 'undo', 'redo' ]
+	toolbar: [ 'headings', 'undo', 'redo' ],
+	image: {
+		toolbar: [ 'imageStyleFull', 'imageStyleSide' ]
+	}
 } )
 .then( editor => {
 	window.editor = editor;

--- a/tests/manual/textalternative.js
+++ b/tests/manual/textalternative.js
@@ -17,7 +17,10 @@ import ImageToolbar from '../../src/imagetoolbar';
 
 ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ EnterPlugin, TypingPlugin, ParagraphPlugin, HeadingPlugin, ImagePlugin, UndoPlugin, ClipboardPlugin, ImageToolbar ],
-	toolbar: [ 'headings', 'undo', 'redo' ]
+	toolbar: [ 'headings', 'undo', 'redo' ],
+	image: {
+		toolbar: [ 'imageTextAlternative' ]
+	}
 } )
 .then( editor => {
 	window.editor = editor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed `config.image.defaultToolbar`. Closes ckeditor/ckeditor5#5070.

BREAKING CHANGE: The `config.image.defaultToolbar` is no longer available. All editor instances must configure `config.image.toolbar` instead.