### PR TITLE
t/109: The arrow of the toolbar's balloon should inherit the background color

### DIFF
--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -70,7 +70,8 @@ export default class ImageToolbar extends Plugin {
 		Template.extend( panel.template, {
 			attributes: {
 				class: [
-					'ck-toolbar-container'
+					'ck-toolbar-container',
+					'ck-editor-toolbar-container'
 				]
 			}
 		} );

--- a/tests/imagetoolbar.js
+++ b/tests/imagetoolbar.js
@@ -58,6 +58,7 @@ describe( 'ImageToolbar', () => {
 
 	it( 'should set css classes', () => {
 		expect( panel.element.classList.contains( 'ck-toolbar-container' ) ).to.be.true;
+		expect( panel.element.classList.contains( 'ck-editor-toolbar-container' ) ).to.be.true;
 		expect( panel.content.get( 0 ).element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The arrow of the toolbar's balloon should inherit the background color. Closes ckeditor/ckeditor5#5098.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-theme-lark/pull/90
