### PR TITLE
Set high priority to prevent ContextualToolbar from being displayed.

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -54,7 +54,7 @@ export default class Image extends Plugin {
 				if ( selectedElement && isImageWidget( selectedElement ) ) {
 					evt.stop();
 				}
-			} );
+			}, { priority: 'high' } );
 		}
 	}
 }

--- a/tests/image.js
+++ b/tests/image.js
@@ -103,17 +103,20 @@ describe( 'Image', () => {
 
 		it( 'should listen to ContextualToolbar#show event with high priority', () => {
 			const highestPrioritySpy = sinon.spy();
+			const highPrioritySpy = sinon.spy();
 			const normalPrioritySpy = sinon.spy();
 
 			// Select an image
 			setModelData( newEditor.document, '<paragraph>foo</paragraph>[<image alt="alt text" src="foo.png"></image>]' );
 
 			newEditor.listenTo( contextualToolbar, 'show', highestPrioritySpy, { priority: 'highest' } );
+			newEditor.listenTo( contextualToolbar, 'show', highPrioritySpy, { priority: 'high' } );
 			newEditor.listenTo( contextualToolbar, 'show', normalPrioritySpy, { priority: 'normal' } );
 
 			contextualToolbar.show();
 
 			sinon.assert.calledOnce( highestPrioritySpy );
+			sinon.assert.notCalled( highPrioritySpy );
 			sinon.assert.notCalled( normalPrioritySpy );
 		} );
 	} );

--- a/tests/image.js
+++ b/tests/image.js
@@ -11,9 +11,6 @@ import ImageTextAlternative from '../src/imagetextalternative';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
-import ContextualToolbar from '@ckeditor/ckeditor5-ui/src/toolbar/contextual/contextualtoolbar';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import View from '@ckeditor/ckeditor5-ui/src/view';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 describe( 'Image', () => {
@@ -53,72 +50,6 @@ describe( 'Image', () => {
 
 	it( 'should load ImageTextAlternative plugin', () => {
 		expect( editor.plugins.get( ImageTextAlternative ) ).to.instanceOf( ImageTextAlternative );
-	} );
-
-	describe( 'ContextualToolbar integration', () => {
-		let balloon, contextualToolbar, newEditor;
-
-		beforeEach( () => {
-			return ClassicTestEditor.create( editorElement, {
-				plugins: [ Image, ContextualToolbar, Paragraph ]
-			} )
-				.then( editor => {
-					newEditor = editor;
-					balloon = newEditor.plugins.get( 'ContextualBalloon' );
-					contextualToolbar = newEditor.plugins.get( 'ContextualToolbar' );
-					const button = new View();
-
-					button.element = global.document.createElement( 'div' );
-
-					// There must be at least one toolbar items which is not disabled to show it.
-					// https://github.com/ckeditor/ckeditor5-ui/issues/269
-					contextualToolbar.toolbarView.items.add( button );
-
-					newEditor.editing.view.isFocused = true;
-				} );
-		} );
-
-		afterEach( () => {
-			editorElement.remove();
-			return newEditor.destroy();
-		} );
-
-		it( 'should prevent the ContextualToolbar from being displayed when an image is selected', () => {
-			// When image is selected along with text.
-			setModelData( newEditor.document, '<paragraph>fo[o</paragraph><image alt="alt text" src="foo.png"></image>]' );
-
-			contextualToolbar.show();
-
-			// ContextualToolbar should be visible.
-			expect( balloon.visibleView ).to.equal( contextualToolbar.toolbarView );
-
-			// When only image is selected.
-			setModelData( newEditor.document, '<paragraph>foo</paragraph>[<image alt="alt text" src="foo.png"></image>]' );
-
-			contextualToolbar.show();
-
-			// ContextualToolbar should not be visible.
-			expect( balloon.visibleView ).to.be.null;
-		} );
-
-		it( 'should listen to ContextualToolbar#show event with high priority', () => {
-			const highestPrioritySpy = sinon.spy();
-			const highPrioritySpy = sinon.spy();
-			const normalPrioritySpy = sinon.spy();
-
-			// Select an image
-			setModelData( newEditor.document, '<paragraph>foo</paragraph>[<image alt="alt text" src="foo.png"></image>]' );
-
-			newEditor.listenTo( contextualToolbar, 'show', highestPrioritySpy, { priority: 'highest' } );
-			newEditor.listenTo( contextualToolbar, 'show', highPrioritySpy, { priority: 'high' } );
-			newEditor.listenTo( contextualToolbar, 'show', normalPrioritySpy, { priority: 'normal' } );
-
-			contextualToolbar.show();
-
-			sinon.assert.calledOnce( highestPrioritySpy );
-			sinon.assert.notCalled( highPrioritySpy );
-			sinon.assert.notCalled( normalPrioritySpy );
-		} );
 	} );
 
 	describe( 'selection', () => {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -1,0 +1,83 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import ContextualToolbar from '@ckeditor/ckeditor5-ui/src/toolbar/contextual/contextualtoolbar';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import Image from '../src/image';
+import View from '@ckeditor/ckeditor5-ui/src/view';
+
+describe( 'Image integration', () => {
+	describe( 'with the ContextualToolbar', () => {
+		let balloon, contextualToolbar, newEditor, editorElement;
+
+		beforeEach( () => {
+			editorElement = global.document.createElement( 'div' );
+			global.document.body.appendChild( editorElement );
+
+			return ClassicTestEditor.create( editorElement, {
+				plugins: [ Image, ContextualToolbar, Paragraph ]
+			} )
+			.then( editor => {
+				newEditor = editor;
+				balloon = newEditor.plugins.get( 'ContextualBalloon' );
+				contextualToolbar = newEditor.plugins.get( 'ContextualToolbar' );
+				const button = new View();
+
+				button.element = global.document.createElement( 'div' );
+
+				// There must be at least one toolbar items which is not disabled to show it.
+				// https://github.com/ckeditor/ckeditor5-ui/issues/269
+				contextualToolbar.toolbarView.items.add( button );
+
+				newEditor.editing.view.isFocused = true;
+			} );
+		} );
+
+		afterEach( () => {
+			editorElement.remove();
+			return newEditor.destroy();
+		} );
+
+		it( 'should prevent the ContextualToolbar from being displayed when an image is selected', () => {
+			// When image is selected along with text.
+			setModelData( newEditor.document, '<paragraph>fo[o</paragraph><image alt="alt text" src="foo.png"></image>]' );
+
+			contextualToolbar.show();
+
+			// ContextualToolbar should be visible.
+			expect( balloon.visibleView ).to.equal( contextualToolbar.toolbarView );
+
+			// When only image is selected.
+			setModelData( newEditor.document, '<paragraph>foo</paragraph>[<image alt="alt text" src="foo.png"></image>]' );
+
+			contextualToolbar.show();
+
+			// ContextualToolbar should not be visible.
+			expect( balloon.visibleView ).to.be.null;
+		} );
+
+		it( 'should listen to ContextualToolbar#show event with the high priority', () => {
+			const highestPrioritySpy = sinon.spy();
+			const highPrioritySpy = sinon.spy();
+			const normalPrioritySpy = sinon.spy();
+
+			// Select an image
+			setModelData( newEditor.document, '<paragraph>foo</paragraph>[<image alt="alt text" src="foo.png"></image>]' );
+
+			newEditor.listenTo( contextualToolbar, 'show', highestPrioritySpy, { priority: 'highest' } );
+			newEditor.listenTo( contextualToolbar, 'show', highPrioritySpy, { priority: 'high' } );
+			newEditor.listenTo( contextualToolbar, 'show', normalPrioritySpy, { priority: 'normal' } );
+
+			contextualToolbar.show();
+
+			sinon.assert.calledOnce( highestPrioritySpy );
+			sinon.assert.notCalled( highPrioritySpy );
+			sinon.assert.notCalled( normalPrioritySpy );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Set high priority to prevent `ContextualToolbar` from being displayed. Closes ckeditor/ckeditor5#5112.
