### PR TITLE
Added "responsive" attribute to image element in model

### DIFF
--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -80,6 +80,11 @@ export function createImageAttributeConverter( dispatchers, attributeName, conve
 	}
 }
 
+/**
+ * Converter used to convert `responsive` image's attribute to `srcset`, `sizes` and `width` attributes in the view.
+ *
+ * @return {Function}
+ */
 export function responsiveAttributeConverter() {
 	return ( evt, data, consumable, conversionApi ) => {
 		const parts = evt.name.split( ':' );

--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -69,32 +69,73 @@ export function viewFigureToModel() {
  *
  * @param {Array.<module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher>} dispatchers
  * @param {String} attributeName
- * @param {function} [conversionCallback] The function that will be called each time given attribute conversion is performed.
- * It will be called with two parameters: a view image element and the type of the conversion: 'addAttribute`, `changeAttribute` or
- * `removeAttribute`. This callback can be used to perform additional processing on view image element.
+ * @param {Function} [converter] Custom converter for attribute - default one converts attribute from model to the same
+ * attribute in the view.
  */
-export function createImageAttributeConverter( dispatchers, attributeName, conversionCallback ) {
+export function createImageAttributeConverter( dispatchers, attributeName, converter = modelToViewAttributeConverter ) {
 	for ( const dispatcher of dispatchers ) {
-		dispatcher.on( `addAttribute:${ attributeName }:image`, modelToViewAttributeConverter( conversionCallback ) );
-		dispatcher.on( `changeAttribute:${ attributeName }:image`, modelToViewAttributeConverter( conversionCallback ) );
-		dispatcher.on( `removeAttribute:${ attributeName }:image`, modelToViewAttributeConverter( conversionCallback ) );
+		dispatcher.on( `addAttribute:${ attributeName }:image`, converter() );
+		dispatcher.on( `changeAttribute:${ attributeName }:image`, converter() );
+		dispatcher.on( `removeAttribute:${ attributeName }:image`, converter() );
 	}
 }
 
-// Returns model to view image converter converting given attribute, and adding it to `img` element nested inside `figure` element.
-// Allows to provide `conversionCallback` called each time conversion is made.
-//
-// @private
-function modelToViewAttributeConverter( conversionCallback ) {
+export function responsiveAttributeConverter() {
 	return ( evt, data, consumable, conversionApi ) => {
 		const parts = evt.name.split( ':' );
 		const consumableType = parts[ 0 ] + ':' + parts[ 1 ];
+		const modelImage = data.item;
 
-		if ( !consumable.consume( data.item, consumableType ) ) {
+		if ( !consumable.consume( modelImage, consumableType ) ) {
 			return;
 		}
 
-		const figure = conversionApi.mapper.toViewElement( data.item );
+		const figure = conversionApi.mapper.toViewElement( modelImage );
+		const img = figure.getChild( 0 );
+		const type = parts[ 0 ];
+
+		if ( type == 'removeAttribute' ) {
+			const oldData = data.attributeOldValue;
+
+			if ( oldData.srcset ) {
+				img.removeAttribute( 'srcset' );
+				img.removeAttribute( 'sizes' );
+
+				if ( oldData.width ) {
+					img.removeAttribute( 'width' );
+				}
+			}
+		} else {
+			const newData = data.attributeNewValue;
+
+			if ( newData.srcset ) {
+				img.setAttribute( 'srcset', newData.srcset );
+				// Always outputting `100vw`. See https://github.com/ckeditor/ckeditor5-image/issues/2.
+				img.setAttribute( 'sizes', '100vw' );
+
+				if ( newData.width ) {
+					img.setAttribute( 'width', newData.width );
+				}
+			}
+		}
+	};
+}
+
+// Returns model to view image converter converting given attribute, and adding it to `img` element nested inside `figure` element.
+// Allows to provide `customConverter` function which if provided will replace 1 to 1 attribute conversion with custom one.
+//
+// @private
+function modelToViewAttributeConverter() {
+	return ( evt, data, consumable, conversionApi ) => {
+		const parts = evt.name.split( ':' );
+		const consumableType = parts[ 0 ] + ':' + parts[ 1 ];
+		const modelImage = data.item;
+
+		if ( !consumable.consume( modelImage, consumableType ) ) {
+			return;
+		}
+
+		const figure = conversionApi.mapper.toViewElement( modelImage );
 		const img = figure.getChild( 0 );
 		const type = parts[ 0 ];
 
@@ -102,10 +143,6 @@ function modelToViewAttributeConverter( conversionCallback ) {
 			img.removeAttribute( data.attributeKey );
 		} else {
 			img.setAttribute( data.attributeKey, data.attributeNewValue );
-		}
-
-		if ( conversionCallback ) {
-			conversionCallback( img, type );
 		}
 	};
 }

--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -69,8 +69,8 @@ export function viewFigureToModel() {
  *
  * @param {Array.<module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher>} dispatchers
  * @param {String} attributeName
- * @param {Function} [converter] Custom converter for attribute - default one converts attribute from model to the same
- * attribute in the view.
+ * @param {Function} [converter] Custom converter for the attribute - default one converts attribute from model `image` element
+ * to the same attribute in `img` in the view.
  */
 export function createImageAttributeConverter( dispatchers, attributeName, converter = modelToViewAttributeConverter ) {
 	for ( const dispatcher of dispatchers ) {
@@ -127,7 +127,6 @@ export function responsiveAttributeConverter() {
 }
 
 // Returns model to view image converter converting given attribute, and adding it to `img` element nested inside `figure` element.
-// Allows to provide `customConverter` function which if provided will replace 1 to 1 attribute conversion with custom one.
 //
 // @private
 function modelToViewAttributeConverter() {

--- a/src/image/imageengine.js
+++ b/src/image/imageengine.js
@@ -24,7 +24,7 @@ import ViewEmptyElement from '@ckeditor/ckeditor5-engine/src/view/emptyelement';
 
 /**
  * The image engine plugin.
- * Registers `<image>` as a block element in the document schema and allows it to have two attributes: `src` and `alt`.
+ * Registers `<image>` as a block element in the document schema, and allows `alt`, `src` and `responsive` attributes.
  * Registers converters for editing and data pipelines.
  *
  * @extends module:core/plugin~Plugin

--- a/tests/imagestyle/imagestyleengine.js
+++ b/tests/imagestyle/imagestyleengine.js
@@ -141,7 +141,7 @@ describe( 'ImageStyleEngine', () => {
 		} );
 
 		it( 'should convert model to view: removing attribute', () => {
-			setModelData( document, '<image src="foo.png" imageStyle="imageStyleSide"></image>' );
+			setModelData( document, '<image src="foo.png" imageStyle="sideStyle"></image>' );
 			const image = document.getRoot().getChild( 0 );
 			const batch = document.batch();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Replaced `srcset` attribute in the model by `responsive` attribute which is now converted to three attributes in the view: `srcset`, `sizes` and `width`. Closes ckeditor/ckeditor5#5120. Closes https://github.com/ckeditor/ckeditor5-easy-image/issues/4.

BREAKING CHANGE: The `srcset` attribute is now replaced by `responsive` attribute in the model.

---

### Additional information

Related changes in `ckeditor5-upload` repository: https://github.com/ckeditor/ckeditor5-upload/tree/t/ckeditor5-image/145
