### PR TITLE
Event names don't have to be normalized to consumable types anymore

### DIFF
--- a/src/imagestyle/converters.js
+++ b/src/imagestyle/converters.js
@@ -18,10 +18,7 @@ import { isImage } from '../image/utils';
  */
 export function modelToViewStyleAttribute( styles ) {
 	return ( evt, data, consumable, conversionApi ) => {
-		const eventType = evt.name.split( ':' )[ 0 ];
-		const consumableType = eventType + ':imageStyle';
-
-		if ( !consumable.consume( data.item, consumableType ) ) {
+		if ( !consumable.consume( data.item, evt.name ) ) {
 			return;
 		}
 

--- a/tests/image/imageengine.js
+++ b/tests/image/imageengine.js
@@ -88,11 +88,9 @@ describe( 'ImageEngine', () => {
 
 			it( 'should not convert srcset attribute if is already consumed', () => {
 				editor.data.modelToView.on( 'attribute:srcset:image', ( evt, data, consumable ) => {
-					const parts = evt.name.split( ':' );
-					const consumableType = parts[ 0 ] + ':' + parts[ 1 ];
 					const modelImage = data.item;
 
-					consumable.consume( modelImage, consumableType );
+					consumable.consume( modelImage, evt.name );
 				}, { priority: 'high' } );
 
 				setModelData( model,
@@ -559,11 +557,9 @@ describe( 'ImageEngine', () => {
 
 			it( 'should not convert srcset attribute if is already consumed', () => {
 				editor.editing.modelToView.on( 'attribute:srcset:image', ( evt, data, consumable ) => {
-					const parts = evt.name.split( ':' );
-					const consumableType = parts[ 0 ] + ':' + parts[ 1 ];
 					const modelImage = data.item;
 
-					consumable.consume( modelImage, consumableType );
+					consumable.consume( modelImage, evt.name );
 				}, { priority: 'high' } );
 
 				setModelData( model,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Event names don't have to be normalized to consumable types anymore.

---

### Additional information

This PR is related to https://github.com/ckeditor/ckeditor5-engine/pull/1241