### PR TITLE
Removed `.ck-editor-toolbar` and `.ck-editor-toolbar-container` classes.

### DIFF
--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -13,7 +13,7 @@ import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextu
 import { isImageWidgetSelected } from './image/utils';
 import { repositionContextualBalloon, getBalloonPositionData } from './image/ui/utils';
 
-const balloonClassName = 'ck-toolbar-container ck-editor-toolbar-container';
+const balloonClassName = 'ck-toolbar-container';
 
 /**
  * The image toolbar class. Creates an image toolbar that shows up when the image widget is selected.
@@ -68,13 +68,6 @@ export default class ImageToolbar extends Plugin {
 		 * @type {module:ui/toolbar/toolbarview~ToolbarView}
 		 */
 		this._toolbar = new ToolbarView();
-
-		// Add CSS class to the toolbar.
-		this._toolbar.extendTemplate( {
-			attributes: {
-				class: 'ck-editor-toolbar'
-			}
-		} );
 
 		// Add buttons to the toolbar.
 		this._toolbar.fillFromConfig( toolbarConfig, editor.ui.componentFactory );

--- a/tests/imagetoolbar.js
+++ b/tests/imagetoolbar.js
@@ -79,11 +79,9 @@ describe( 'ImageToolbar', () => {
 
 			setData( model, '[<image src=""></image>]' );
 
-			expect( toolbar.element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
-
 			sinon.assert.calledWithMatch( spy, {
 				view: toolbar,
-				balloonClassName: 'ck-toolbar-container ck-editor-toolbar-container'
+				balloonClassName: 'ck-toolbar-container'
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

BREAKING CHANGE:  Removed `.ck-editor-toolbar` and `.ck-editor-toolbar-container` classes in `ImageToolbar`.

---

### Additional information

* A piece of https://github.com/ckeditor/ckeditor5-theme-lark/issues/135
