### PR TITLE
t/187: Made the image text alternative form buttons thicker with a fill color and no background

### DIFF
--- a/src/imagetextalternative/ui/textalternativeformview.js
+++ b/src/imagetextalternative/ui/textalternativeformview.js
@@ -65,7 +65,7 @@ export default class TextAlternativeFormView extends View {
 		 *
 		 * @member {module:ui/button/buttonview~ButtonView} #saveButtonView
 		 */
-		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon );
+		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon, 'ck-button_save' );
 		this.saveButtonView.type = 'submit';
 
 		/**
@@ -73,7 +73,7 @@ export default class TextAlternativeFormView extends View {
 		 *
 		 * @member {module:ui/button/buttonview~ButtonView} #cancelButtonView
 		 */
-		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon, 'cancel' );
+		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon, 'ck-button_cancel', 'cancel' );
 
 		/**
 		 * A collection of views which can be focused in the form.
@@ -101,14 +101,6 @@ export default class TextAlternativeFormView extends View {
 
 				// Navigate form fields forwards using the Tab key.
 				focusNext: 'tab'
-			}
-		} );
-
-		this.saveButtonView.extendTemplate( {
-			attributes: {
-				class: [
-					'ck-button-action'
-				]
 			}
 		} );
 
@@ -158,16 +150,23 @@ export default class TextAlternativeFormView extends View {
 	 * @private
 	 * @param {String} label The button label
 	 * @param {String} icon The button's icon.
+	 * @param {String} className The additional button CSS class name.
 	 * @param {String} [eventName] The event name that the ButtonView#execute event will be delegated to.
 	 * @returns {module:ui/button/buttonview~ButtonView} The button view instance.
 	 */
-	_createButton( label, icon, eventName ) {
+	_createButton( label, icon, className, eventName ) {
 		const button = new ButtonView( this.locale );
 
 		button.set( {
 			label,
 			icon,
 			tooltip: true
+		} );
+
+		button.extendTemplate( {
+			attributes: {
+				class: className
+			}
 		} );
 
 		if ( eventName ) {

--- a/src/imagetextalternative/ui/textalternativeformview.js
+++ b/src/imagetextalternative/ui/textalternativeformview.js
@@ -65,7 +65,7 @@ export default class TextAlternativeFormView extends View {
 		 *
 		 * @member {module:ui/button/buttonview~ButtonView} #saveButtonView
 		 */
-		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon, 'ck-button_save' );
+		this.saveButtonView = this._createButton( t( 'Save' ), checkIcon, 'ck-button-save' );
 		this.saveButtonView.type = 'submit';
 
 		/**
@@ -73,7 +73,7 @@ export default class TextAlternativeFormView extends View {
 		 *
 		 * @member {module:ui/button/buttonview~ButtonView} #cancelButtonView
 		 */
-		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon, 'ck-button_cancel', 'cancel' );
+		this.cancelButtonView = this._createButton( t( 'Cancel' ), cancelIcon, 'ck-button-cancel', 'cancel' );
 
 		/**
 		 * A collection of views which can be focused in the form.

--- a/tests/imagetextalternative/ui/textalternativeformview.js
+++ b/tests/imagetextalternative/ui/textalternativeformview.js
@@ -46,8 +46,8 @@ describe( 'TextAlternativeFormView', () => {
 
 			view.render();
 
-			expect( view.saveButtonView.element.classList.contains( 'ck-button_save' ) ).to.be.true;
-			expect( view.cancelButtonView.element.classList.contains( 'ck-button_cancel' ) ).to.be.true;
+			expect( view.saveButtonView.element.classList.contains( 'ck-button-save' ) ).to.be.true;
+			expect( view.cancelButtonView.element.classList.contains( 'ck-button-cancel' ) ).to.be.true;
 		} );
 
 		it( 'should create #_focusCycler instance', () => {

--- a/tests/imagetextalternative/ui/textalternativeformview.js
+++ b/tests/imagetextalternative/ui/textalternativeformview.js
@@ -43,6 +43,9 @@ describe( 'TextAlternativeFormView', () => {
 			expect( view.labeledInput ).to.be.instanceOf( View );
 			expect( view.saveButtonView ).to.be.instanceOf( View );
 			expect( view.cancelButtonView ).to.be.instanceOf( View );
+
+			expect( view.saveButtonView.element.classList.contains( 'ck-button_save' ) ).to.be.true;
+			expect( view.cancelButtonView.element.classList.contains( 'ck-button_cancel' ) ).to.be.true;
 		} );
 
 		it( 'should create #_focusCycler instance', () => {

--- a/tests/imagetextalternative/ui/textalternativeformview.js
+++ b/tests/imagetextalternative/ui/textalternativeformview.js
@@ -44,6 +44,8 @@ describe( 'TextAlternativeFormView', () => {
 			expect( view.saveButtonView ).to.be.instanceOf( View );
 			expect( view.cancelButtonView ).to.be.instanceOf( View );
 
+			view.render();
+
 			expect( view.saveButtonView.element.classList.contains( 'ck-button_save' ) ).to.be.true;
 			expect( view.cancelButtonView.element.classList.contains( 'ck-button_cancel' ) ).to.be.true;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Made the image text alternative form buttons thicker with a fill color and no background. Closes ckeditor/ckeditor5#5137.

---

### Additional information

![image](https://user-images.githubusercontent.com/1099479/37466792-eb66f196-285e-11e8-9929-3320e6810d9b.png)

Requires:
1. https://github.com/ckeditor/ckeditor5-link/pull/185
2. https://github.com/ckeditor/ckeditor5-theme-lark/pull/162