### PR TITLE
Image element should be cleared from progress if uploadId changed to null

### DIFF
--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -60,12 +60,12 @@ export default class ImageUploadProgress extends Plugin {
 		const modelImage = data.item;
 		const uploadId = modelImage.getAttribute( 'uploadId' );
 
-		if ( !conversionApi.consumable.consume( data.item, evt.name ) || !uploadId ) {
+		if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
 			return;
 		}
 
 		const fileRepository = editor.plugins.get( FileRepository );
-		const status = data.attributeNewValue;
+		const status = uploadId ? data.attributeNewValue : null;
 		const placeholder = this.placeholder;
 		const viewFigure = editor.editing.mapper.toViewElement( modelImage );
 		const viewWriter = conversionApi.writer;

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -137,6 +137,28 @@ describe( 'ImageUploadProgress', () => {
 		);
 	} );
 
+	it( 'should "clear" image when uploadId changes to null', () => {
+		setModelData( model, '<image></image>' );
+		const image = document.getRoot().getChild( 0 );
+
+		// Set attributes directly on image to simulate instant "uploading" status.
+		model.change( writer => {
+			writer.setAttribute( 'uploadStatus', 'uploading', image );
+			writer.setAttribute( 'uploadId', '12345', image );
+		} );
+
+		model.change( writer => {
+			writer.setAttribute( 'uploadStatus', null, image );
+			writer.setAttribute( 'uploadId', null, image );
+		} );
+
+		expect( getViewData( view ) ).to.equal(
+			'[<figure class="ck ck-widget image" contenteditable="false">' +
+			`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
+			'</figure>]'
+		);
+	} );
+
 	it( 'should update progressbar width on progress', done => {
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );


### PR DESCRIPTION
Fix: Image element will be cleared from upload progress classes if `uploadId` attribute changed to `null`. Closes ckeditor/ckeditor5#5145.