### PR TITLE
.ck class should not be added to elements inside editor editable

### DIFF
--- a/tests/image.js
+++ b/tests/image.js
@@ -60,7 +60,7 @@ describe( 'Image', () => {
 			setModelData( model, '[<image alt="alt text" src="foo.png"></image>]' );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget ck-widget_selected image" contenteditable="false">' +
+				'[<figure class="ck-widget ck-widget_selected image" contenteditable="false">' +
 					'<img alt="alt text" src="foo.png"></img>' +
 				'</figure>]'
 			);
@@ -73,7 +73,7 @@ describe( 'Image', () => {
 			setModelData( model, '[<image src="foo.png" alt=""></image>]' );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget ck-widget_selected image" contenteditable="false">' +
+				'[<figure class="ck-widget ck-widget_selected image" contenteditable="false">' +
 				'<img alt="" src="foo.png"></img>' +
 				'</figure>]'
 			);
@@ -89,10 +89,10 @@ describe( 'Image', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget ck-widget_selected image" contenteditable="false">' +
+				'[<figure class="ck-widget ck-widget_selected image" contenteditable="false">' +
 				'<img alt="alt text" src="foo.png"></img>' +
 				'</figure>]' +
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 				'<img alt="alt text" src="foo.png"></img>' +
 				'</figure>'
 			);
@@ -103,10 +103,10 @@ describe( 'Image', () => {
 			} );
 
 			expect( getViewData( view ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 				'<img alt="alt text" src="foo.png"></img>' +
 				'</figure>' +
-				'[<figure class="ck ck-widget ck-widget_selected image" contenteditable="false">' +
+				'[<figure class="ck-widget ck-widget_selected image" contenteditable="false">' +
 				'<img alt="alt text" src="foo.png"></img>' +
 				'</figure>]'
 			);

--- a/tests/image/converters.js
+++ b/tests/image/converters.js
@@ -215,7 +215,7 @@ describe( 'Image converters', () => {
 			} );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img alt="foo bar" src=""></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img alt="foo bar" src=""></img></figure>'
 			);
 		} );
 
@@ -228,7 +228,7 @@ describe( 'Image converters', () => {
 			} );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src=""></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src=""></img></figure>'
 			);
 		} );
 
@@ -241,7 +241,7 @@ describe( 'Image converters', () => {
 			} );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img alt="baz quix" src=""></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img alt="baz quix" src=""></img></figure>'
 			);
 		} );
 
@@ -253,7 +253,7 @@ describe( 'Image converters', () => {
 			setModelData( model, '<image src="" alt="foo bar"></image>' );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src=""></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src=""></img></figure>'
 			);
 		} );
 	} );

--- a/tests/image/imageediting.js
+++ b/tests/image/imageediting.js
@@ -381,7 +381,7 @@ describe( 'ImageEditing', () => {
 				setModelData( model, '<image src="foo.png" alt="alt text"></image>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false"><img alt="alt text" src="foo.png"></img></figure>'
+					'<figure class="ck-widget image" contenteditable="false"><img alt="alt text" src="foo.png"></img></figure>'
 				);
 			} );
 
@@ -402,7 +402,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false"><img alt="new text" src="foo.png"></img></figure>'
+					'<figure class="ck-widget image" contenteditable="false"><img alt="new text" src="foo.png"></img></figure>'
 				);
 			} );
 
@@ -415,7 +415,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) )
-					.to.equal( '<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>' );
+					.to.equal( '<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>' );
 			} );
 
 			it( 'should not convert change if is already consumed', () => {
@@ -431,7 +431,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false"><img alt="alt text" src="foo.png"></img></figure>'
+					'<figure class="ck-widget image" contenteditable="false"><img alt="alt text" src="foo.png"></img></figure>'
 				);
 			} );
 
@@ -444,7 +444,7 @@ describe( 'ImageEditing', () => {
 					'</image>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img alt="alt text" sizes="100vw" src="foo.png" srcset="small.png 148w, big.png 1024w"></img>' +
 					'</figure>'
 				);
@@ -464,7 +464,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img alt="alt text" src="foo.png"></img>' +
 					'</figure>'
 				);
@@ -479,7 +479,7 @@ describe( 'ImageEditing', () => {
 					'</image>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img alt="alt text" sizes="100vw" src="foo.png" srcset="small.png 148w, big.png 1024w" width="1024"></img>' +
 					'</figure>'
 				);
@@ -494,7 +494,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="foo.png"></img>' +
 					'</figure>'
 				);
@@ -514,7 +514,7 @@ describe( 'ImageEditing', () => {
 				} );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src="foo.png"></img>' +
 					'</figure>'
 				);
@@ -536,7 +536,7 @@ describe( 'ImageEditing', () => {
 				);
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img alt="alt text" src="foo.png"></img>' +
 					'</figure>'
 				);

--- a/tests/imagecaption/imagecaptionediting.js
+++ b/tests/imagecaption/imagecaptionediting.js
@@ -111,9 +111,9 @@ describe( 'ImageCaptionEditing', () => {
 				setModelData( model, '<image src="img.png"><caption>Foo bar baz.</caption></image>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'Foo bar baz.' +
 						'</figcaption>' +
@@ -126,9 +126,9 @@ describe( 'ImageCaptionEditing', () => {
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 					'<p>foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -159,7 +159,7 @@ describe( 'ImageCaptionEditing', () => {
 				setModelData( model, '<image src="img.png"><caption>Foo bar baz.</caption></image>' );
 
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
-					'<figure class="ck ck-widget image" contenteditable="false"><img src="img.png"></img><span></span>Foo bar baz.</figure>'
+					'<figure class="ck-widget image" contenteditable="false"><img src="img.png"></img><span></span>Foo bar baz.</figure>'
 				);
 			} );
 
@@ -175,9 +175,9 @@ describe( 'ImageCaptionEditing', () => {
 
 				expect( getViewData( view ) ).to.equal(
 					'<p>{}foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'foo bar' +
 						'</figcaption>' +
@@ -197,9 +197,9 @@ describe( 'ImageCaptionEditing', () => {
 
 				expect( getViewData( view ) ).to.equal(
 					'<p>{}foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -218,9 +218,9 @@ describe( 'ImageCaptionEditing', () => {
 
 				expect( getViewData( view ) ).to.equal(
 					'<p>{}foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">baz</figcaption>' +
 					'</figure>'
 				);
@@ -239,9 +239,9 @@ describe( 'ImageCaptionEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]' +
@@ -262,9 +262,9 @@ describe( 'ImageCaptionEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 						'foo bar' +
 					'</figcaption>' +
@@ -291,9 +291,9 @@ describe( 'ImageCaptionEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]' +
 				'<p></p>'
@@ -321,9 +321,9 @@ describe( 'ImageCaptionEditing', () => {
 
 			expect( getViewData( view ) ).to.equal(
 				'<p>foo</p>' +
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]'
@@ -335,9 +335,9 @@ describe( 'ImageCaptionEditing', () => {
 
 			expect( getViewData( view ) ).to.equal(
 				'<p>{}foo</p>' +
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -349,9 +349,9 @@ describe( 'ImageCaptionEditing', () => {
 
 			expect( getViewData( view ) ).to.equal(
 				'<p>foo</p>' +
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">foo bar</figcaption>' +
 				'</figure>]'
 			);
@@ -366,9 +366,9 @@ describe( 'ImageCaptionEditing', () => {
 
 			expect( getViewData( view ) ).to.equal(
 				'<p>{}foo</p>' +
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -383,9 +383,9 @@ describe( 'ImageCaptionEditing', () => {
 			} );
 
 			expect( getViewData( view ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 						'[]' +
 					'</figcaption>' +
@@ -403,9 +403,9 @@ describe( 'ImageCaptionEditing', () => {
 			} );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -420,14 +420,14 @@ describe( 'ImageCaptionEditing', () => {
 			} );
 
 			expect( getViewData( view ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false">' +
+				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">foo bar</figcaption>' +
 				'</figure>' +
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -450,9 +450,9 @@ describe( 'ImageCaptionEditing', () => {
 				// Check if there is no figcaption in the view.
 				expect( getViewData( view ) ).to.equal(
 					'<p>{}foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -463,9 +463,9 @@ describe( 'ImageCaptionEditing', () => {
 				// Check if figcaption is back with contents.
 				expect( getViewData( view ) ).to.equal(
 					'<p>foo</p>' +
-					'<figure class="ck ck-widget image" contenteditable="false">' +
+					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'{foo bar baz}' +
 						'</figcaption>' +

--- a/tests/imagestyle/imagestyleediting.js
+++ b/tests/imagestyle/imagestyleediting.js
@@ -92,7 +92,7 @@ describe( 'ImageStyleEditing', () => {
 				.to.equal( '<image imageStyle="sideStyle" src="foo.png"></image>' );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image side-class" contenteditable="false">' +
+				'<figure class="ck-widget image side-class" contenteditable="false">' +
 					'<img src="foo.png"></img>' +
 				'</figure>' );
 		} );
@@ -102,7 +102,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equal( '<image src="foo.png"></image>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -124,7 +124,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equal( '<image src="foo.png"></image>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -138,7 +138,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<figure class="image side-class"><img src="foo.png"></figure>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image side-class" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image side-class" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -152,7 +152,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<figure class="image"><img src="foo.png"></figure>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -168,7 +168,7 @@ describe( 'ImageStyleEditing', () => {
 
 			// https://github.com/ckeditor/ckeditor5-image/issues/132
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image side-class" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image side-class" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 
 			model.change( writer => {
@@ -179,7 +179,7 @@ describe( 'ImageStyleEditing', () => {
 
 			// https://github.com/ckeditor/ckeditor5-image/issues/132
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget dummy-class image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget dummy-class image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -196,7 +196,7 @@ describe( 'ImageStyleEditing', () => {
 			} );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -208,7 +208,7 @@ describe( 'ImageStyleEditing', () => {
 			setModelData( model, '<image src="foo.png" imageStyle="dummyStyle"></image>' );
 
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -222,7 +222,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<figure class="image"><img src="foo.png"></figure>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -236,7 +236,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<figure class="image"><img src="foo.png"></figure>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 
@@ -250,7 +250,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<figure class="image"><img src="foo.png"></figure>' );
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
-				'<figure class="ck ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
+				'<figure class="ck-widget image" contenteditable="false"><img src="foo.png"></img></figure>'
 			);
 		} );
 	} );

--- a/tests/imageupload/imageuploadediting.js
+++ b/tests/imageupload/imageuploadediting.js
@@ -205,7 +205,7 @@ describe( 'ImageUploadEditing', () => {
 		setModelData( model, '<image uploadId="1234"></image>' );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-widget image" contenteditable="false">' +
 				'<img></img>' +
 			'</figure>]' );
 	} );
@@ -217,7 +217,7 @@ describe( 'ImageUploadEditing', () => {
 
 		model.once( '_change', () => {
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-widget image" contenteditable="false">' +
 				`<img src="${ base64Sample }"></img>` +
 				'</figure>]' +
 				'<p>foo bar</p>' );
@@ -238,7 +238,7 @@ describe( 'ImageUploadEditing', () => {
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
 				expect( getViewData( view ) ).to.equal(
-					'[<figure class="ck ck-widget image" contenteditable="false"><img src="image.png"></img></figure>]<p>foo bar</p>'
+					'[<figure class="ck-widget image" contenteditable="false"><img src="image.png"></img></figure>]<p>foo bar</p>'
 				);
 				expect( loader.status ).to.equal( 'idle' );
 
@@ -326,7 +326,7 @@ describe( 'ImageUploadEditing', () => {
 		setModelData( model, '<image src="image.png"></image>' );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-widget image" contenteditable="false"><img src="image.png"></img></figure>]'
+			'[<figure class="ck-widget image" contenteditable="false"><img src="image.png"></img></figure>]'
 		);
 	} );
 
@@ -443,7 +443,7 @@ describe( 'ImageUploadEditing', () => {
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
 				expect( getViewData( view ) ).to.equal(
-					'[<figure class="ck ck-widget image" contenteditable="false">' +
+					'[<figure class="ck-widget image" contenteditable="false">' +
 						'<img sizes="100vw" src="image.png" srcset="image-500.png 500w, image-800.png 800w" width="800"></img>' +
 					'</figure>]<p>foo bar</p>'
 				);

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -73,7 +73,7 @@ describe( 'ImageUploadProgress', () => {
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
 				`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]<p>foo</p>'
 		);
@@ -85,7 +85,7 @@ describe( 'ImageUploadProgress', () => {
 
 		model.document.once( 'change', () => {
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-appear ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-appear ck-widget image" contenteditable="false">' +
 					`<img src="${ base64Sample }"></img>` +
 					'<div class="ck-progress-bar"></div>' +
 				'</figure>]<p>foo</p>'
@@ -113,7 +113,7 @@ describe( 'ImageUploadProgress', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-appear ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-appear ck-widget image" contenteditable="false">' +
 				'<img src="image.png"></img>' +
 				'<div class="ck-progress-bar"></div>' +
 			'</figure>]'
@@ -131,7 +131,7 @@ describe( 'ImageUploadProgress', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
 				`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]'
 		);
@@ -153,7 +153,7 @@ describe( 'ImageUploadProgress', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-widget image" contenteditable="false">' +
 			`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]'
 		);
@@ -167,7 +167,7 @@ describe( 'ImageUploadProgress', () => {
 			adapterMock.mockProgress( 40, 100 );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<figure class="ck ck-appear ck-widget image" contenteditable="false">' +
+				'[<figure class="ck-appear ck-widget image" contenteditable="false">' +
 				`<img src="${ base64Sample }"></img>` +
 				'<div class="ck-progress-bar" style="width:40%"></div>' +
 				'</figure>]<p>foo</p>'
@@ -186,7 +186,7 @@ describe( 'ImageUploadProgress', () => {
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
 				expect( getViewData( view ) ).to.equal(
-					'[<figure class="ck ck-widget image" contenteditable="false">' +
+					'[<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="image.png"></img>' +
 					'</figure>]<p>foo</p>'
 				);
@@ -208,7 +208,7 @@ describe( 'ImageUploadProgress', () => {
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
 				`<img src="${ base64Sample }"></img>` +
 			'</figure>]<p>foo</p>'
 		);
@@ -223,7 +223,7 @@ describe( 'ImageUploadProgress', () => {
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-widget image" contenteditable="false"><img></img></figure>]<p>foo</p>'
+			'[<figure class="ck-widget image" contenteditable="false"><img></img></figure>]<p>foo</p>'
 		);
 	} );
 
@@ -237,7 +237,7 @@ describe( 'ImageUploadProgress', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-appear ck-image-upload-placeholder ck-infinite-progress ck-widget image" contenteditable="false">' +
 				`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]'
 		);
@@ -247,7 +247,7 @@ describe( 'ImageUploadProgress', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<figure class="ck ck-widget image" contenteditable="false">' +
+			'[<figure class="ck-widget image" contenteditable="false">' +
 				`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]'
 		);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `.ck` class should not be added to elements inside editor editable.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/936