### PR TITLE
Fix: Made d&d image upload working when ImageUploadCommand is disabled.

### DIFF
--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -3,7 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
 import ModelSelection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import FileRepository from '@ckeditor/ckeditor5-upload/src/filerepository';
@@ -44,7 +43,7 @@ export default class ImageUploadCommand extends Command {
 				return;
 			}
 
-			const imageElement = new ModelElement( 'image', {
+			const imageElement = writer.createElement( 'image', {
 				uploadId: loader.id
 			} );
 
@@ -60,7 +59,7 @@ export default class ImageUploadCommand extends Command {
 
 			// Inserting an image might've failed due to schema regulations.
 			if ( imageElement.parent ) {
-				writer.setSelection( ModelRange.createOn( imageElement ) );
+				writer.setSelection( imageElement, 'on' );
 			}
 		} );
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Made d&d image upload working when ImageUploadCommand is disabled. Closes ckeditor/ckeditor5#5149.

---

### Requires

- https://github.com/ckeditor/ckeditor5-clipboard/tree/t/ckeditor5-image/208 - commit message: Internal: Disabled `clipboardInput` event when editor is read-only.
