### PR TITLE
Support uploading images pasted from other websites

### DIFF
--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -47,9 +47,9 @@ export default class ImageUploadEditing extends Plugin {
 
 		// Execute imageUpload command when image is dropped or pasted.
 		this.listenTo( editor.editing.view.document, 'clipboardInput', ( evt, data ) => {
-			// Skip if non empty HTML data is included.
+			// Skip if no files to upload
 			// https://github.com/ckeditor/ckeditor5-upload/issues/68
-			if ( isHtmlIncluded( data.dataTransfer ) ) {
+			if ( !data.dataTransfer.files || !data.dataTransfer.files.length ) {
 				return;
 			}
 
@@ -230,12 +230,4 @@ export default class ImageUploadEditing extends Plugin {
 			fileRepository.destroyLoader( loader );
 		}
 	}
-}
-
-// Returns `true` if non-empty `text/html` is included in the data transfer.
-//
-// @param {module:clipboard/datatransfer~DataTransfer} dataTransfer
-// @returns {Boolean}
-export function isHtmlIncluded( dataTransfer ) {
-	return Array.from( dataTransfer.types ).includes( 'text/html' ) && dataTransfer.getData( 'text/html' ) !== '';
 }

--- a/tests/imageupload/imageuploadediting.js
+++ b/tests/imageupload/imageuploadediting.js
@@ -199,23 +199,6 @@ describe( 'ImageUploadEditing', () => {
 		expect( getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph>' );
 	} );
 
-	it( 'should not insert image when there is non-empty HTML content pasted', () => {
-		const fileMock = createNativeFileMock();
-		const dataTransfer = new DataTransfer( {
-			files: [ fileMock ],
-			types: [ 'Files', 'text/html' ],
-			getData: type => type === 'text/html' ? '<p>SomeData</p>' : ''
-		} );
-		setModelData( model, '<paragraph>[]foo</paragraph>' );
-
-		const targetRange = Range.createFromParentsAndOffsets( doc.getRoot(), 1, doc.getRoot(), 1 );
-		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
-
-		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
-
-		expect( getModelData( model ) ).to.equal( '<paragraph>[]foo</paragraph>' );
-	} );
-
 	it( 'should not insert image nor crash when pasted image could not be inserted', () => {
 		model.schema.register( 'other', {
 			allowIn: '$root',


### PR DESCRIPTION
Previous check prevented uploads when copy pasting images from other websites, as these drag events include html data in addition to file data.

Closes ckeditor/ckeditor5#5152 .

---

Image uploads are now triggered when copy pasting an image from a website.

However, they will still not be triggered when drag + dropping an image from a website. This is because the drag event doesn't include file data, but `text/uri-list` data, which includes the image url(s). Similarly, images won't be uploaded if selecting and copying+dragging/pasting a bunch of html.

In these instances, due to potential CORS issues, you would need to have a server endpoint that downloads and saves images directly from these external urls.

Additionally, it may also be worthwhile having a config option to validate img src, to only insert them when the url matches certain patterns. This could be used to prevent re-uploading previously uploaded content, and restrict hotlinking from other websites.