### PR TITLE
Remove complete upload icon in Edge

### DIFF
--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -216,7 +216,7 @@ function _showCompleteIcon( viewFigure, writer, view ) {
 
 		setTimeout( () => {
 			view.change( writer => writer.remove( ViewRange.createOn( completeIcon ) ) );
-		}, 30000 );
+		}, 3000 );
 	}
 }
 

--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -105,7 +105,8 @@ export default class ImageUploadProgress extends Plugin {
 			return;
 		}
 
-		if ( status == 'complete' && fileRepository.loaders.get( uploadId ) ) {
+		// Because in Edge there is no way to show fancy animation of completeIcon we need to skip it.
+		if ( status == 'complete' && fileRepository.loaders.get( uploadId ) && !env.isEdge ) {
 			_showCompleteIcon( viewFigure, viewWriter, editor.editing.view );
 		}
 
@@ -210,14 +211,11 @@ function _hideProgressBar( viewFigure, writer ) {
 function _showCompleteIcon( viewFigure, writer, view ) {
 	const completeIcon = new UIElement( 'div', { class: 'ck-image-upload-complete-icon' } );
 
-	// Because in Edge there is no way to show fancy animation of completeIcon we need to skip it.
-	if ( !env.isEdge ) {
-		writer.insert( ViewPosition.createAt( viewFigure, 'end' ), completeIcon );
+	writer.insert( ViewPosition.createAt( viewFigure, 'end' ), completeIcon );
 
-		setTimeout( () => {
-			view.change( writer => writer.remove( ViewRange.createOn( completeIcon ) ) );
-		}, 3000 );
-	}
+	setTimeout( () => {
+		view.change( writer => writer.remove( ViewRange.createOn( completeIcon ) ) );
+	}, 3000 );
 }
 
 // Create progress bar element using {@link module:engine/view/uielement~UIElement}.

--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -15,6 +15,7 @@ import uploadingPlaceholder from '../../theme/icons/image_placeholder.svg';
 import UIElement from '@ckeditor/ckeditor5-engine/src/view/uielement';
 import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
 import ViewRange from '@ckeditor/ckeditor5-engine/src/view/range';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import '../../theme/imageuploadprogress.css';
 import '../../theme/imageuploadicon.css';
@@ -209,11 +210,14 @@ function _hideProgressBar( viewFigure, writer ) {
 function _showCompleteIcon( viewFigure, writer, view ) {
 	const completeIcon = new UIElement( 'div', { class: 'ck-image-upload-complete-icon' } );
 
-	writer.insert( ViewPosition.createAt( viewFigure, 'end' ), completeIcon );
+	// Because in Edge there is no way to show fancy animation of completeIcon we need to skip it.
+	if ( !env.isEdge ) {
+		writer.insert( ViewPosition.createAt( viewFigure, 'end' ), completeIcon );
 
-	setTimeout( () => {
-		view.change( writer => writer.remove( ViewRange.createOn( completeIcon ) ) );
-	}, 3000 );
+		setTimeout( () => {
+			view.change( writer => writer.remove( ViewRange.createOn( completeIcon ) ) );
+		}, 30000 );
+	}
 }
 
 // Create progress bar element using {@link module:engine/view/uielement~UIElement}.

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -19,6 +19,7 @@ import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-util
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import svgPlaceholder from '../../theme/icons/image_placeholder.svg';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'ImageUploadProgress', () => {
 	const imagePlaceholder = encodeURIComponent( svgPlaceholder );
@@ -262,5 +263,26 @@ describe( 'ImageUploadProgress', () => {
 				`<img src="data:image/svg+xml;utf8,${ imagePlaceholder }"></img>` +
 			'</figure>]'
 		);
+	} );
+
+	it( 'should not create completeIcon element when browser is Microsoft Edge', () => {
+		env.isEdge = true;
+
+		setModelData( model, '<paragraph>[]foo</paragraph>' );
+		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+
+		model.document.once( 'change', () => {
+			model.document.once( 'change', () => {
+				expect( getViewData( view ) ).to.equal(
+					'[<figure class="ck-widget image" contenteditable="false">' +
+						'<img src="image.png"></img>' +
+					'</figure>]<p>foo</p>'
+				);
+			}, { priority: 'lowest' } );
+
+			adapterMock.mockSuccess( { default: 'image.png' } );
+		} );
+
+		nativeReaderMock.mockSuccess( base64Sample );
 	} );
 } );

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -266,7 +266,7 @@ describe( 'ImageUploadProgress', () => {
 	} );
 
 	it( 'should not create completeIcon element when browser is Microsoft Edge', () => {
-		env.isEdge = true;
+		testUtils.sinon.stub( env, 'isEdge' ).returns( true );
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -265,8 +265,8 @@ describe( 'ImageUploadProgress', () => {
 		);
 	} );
 
-	it( 'should not create completeIcon element when browser is Microsoft Edge', () => {
-		testUtils.sinon.stub( env, 'isEdge' ).returns( true );
+	it( 'should not create completeIcon element when browser is Microsoft Edge', done => {
+		testUtils.sinon.stub( env, 'isEdge' ).get( () => true );
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
 		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
@@ -274,10 +274,12 @@ describe( 'ImageUploadProgress', () => {
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
 				expect( getViewData( view ) ).to.equal(
-					'[<figure class="ck-widget image" contenteditable="false">' +
+					'[<figure class="ck-widget image">' +
 						'<img src="image.png"></img>' +
 					'</figure>]<p>foo</p>'
 				);
+
+				done();
 			}, { priority: 'lowest' } );
 
 			adapterMock.mockSuccess( { default: 'image.png' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Complete upload icon should not be rendered in Edge. Closes ckeditor/ckeditor5/issues/1066.

