### PR TITLE
t/225: The ImageUploadCommand should check whether it can be executed in the selection context.

### DIFF
--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -19,6 +19,23 @@ import Command from '@ckeditor/ckeditor5-core/src/command';
  */
 export default class ImageUploadCommand extends Command {
 	/**
+	 * @inheritDoc
+	 */
+	refresh() {
+		const model = this.editor.model;
+		const selection = model.document.selection;
+		const schema = model.schema;
+		const position = selection.getFirstPosition();
+		let parent = position.parent;
+
+		if ( parent != parent.root ) {
+			parent = parent.parent;
+		}
+
+		this.isEnabled = schema.checkChild( parent, 'image' );
+	}
+
+	/**
 	 * Executes the command.
 	 *
 	 * @fires execute

--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -84,8 +84,8 @@ function isImageAllowedInParent( selection, schema ) {
 }
 
 // Additional check for when the command should be disabled:
-// - selection is on image
-// - selection is inside image (image caption)
+// - selection is on object
+// - selection is inside object
 function checkSelectionWithObject( selection, schema ) {
 	const selectedElement = selection.getSelectedElement();
 

--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -40,7 +40,7 @@ export default class ImageUploadCommand extends Command {
 	 *
 	 * @fires execute
 	 * @param {Object} options Options for the executed command.
-	 * @param {File|Array.<File>} options.file The image file or an array of image files to upload.
+	 * @param {File|Array.<File>} options.files The image file or an array of image files to upload.
 	 * @param {module:engine/model/position~Position} [options.insertAt] The position at which the images should be inserted.
 	 * If the position is not specified, the image will be inserted into the current selection.
 	 * Note: You can use the {@link module:widget/utils~findOptimalInsertionPosition} function
@@ -50,7 +50,7 @@ export default class ImageUploadCommand extends Command {
 		const editor = this.editor;
 
 		editor.model.change( writer => {
-			const filesToUpload = Array.isArray( options.file ) ? options.file : [ options.file ];
+			const filesToUpload = Array.isArray( options.files ) ? options.files : [ options.files ];
 
 			// Reverse the order of items as the editor will place in reverse when using the same position.
 			for ( const file of filesToUpload.reverse() ) {

--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -25,7 +25,7 @@ export default class ImageUploadCommand extends Command {
 		const selection = model.document.selection;
 		const schema = model.schema;
 
-		this.isEnabled = isImageAllowedInParent( selection, schema ) && checkSelectionWithImage( selection );
+		this.isEnabled = isImageAllowedInParent( selection, schema ) && checkSelectionWithObject( selection, schema );
 	}
 
 	/**
@@ -86,13 +86,13 @@ function isImageAllowedInParent( selection, schema ) {
 // Additional check for when the command should be disabled:
 // - selection is on image
 // - selection is inside image (image caption)
-function checkSelectionWithImage( selection ) {
+function checkSelectionWithObject( selection, schema ) {
 	const selectedElement = selection.getSelectedElement();
 
-	const isSelectionOnImage = !!selectedElement && selectedElement.is( 'image' );
-	const isSelectionInImage = !![ ...selection.focus.parent.getAncestors() ].find( ancestor => ancestor.name == 'image' );
+	const isSelectionOnObject = !!selectedElement && schema.isObject( selectedElement );
+	const isSelectionInObject = !![ ...selection.focus.getAncestors() ].find( ancestor => schema.isObject( ancestor ) );
 
-	return !isSelectionOnImage && !isSelectionInImage;
+	return !isSelectionOnObject && !isSelectionInObject;
 }
 
 // Returns a node that will be used to insert image with `model.insertContent` to check if image can be placed there.

--- a/src/imageupload/imageuploadcommand.js
+++ b/src/imageupload/imageuploadcommand.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
-import ModelSelection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import FileRepository from '@ckeditor/ckeditor5-upload/src/filerepository';
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
@@ -36,10 +34,6 @@ export default class ImageUploadCommand extends Command {
 	 * @fires execute
 	 * @param {Object} options Options for the executed command.
 	 * @param {File|Array.<File>} options.files The image file or an array of image files to upload.
-	 * @param {module:engine/model/position~Position} [options.insertAt] The position at which the images should be inserted.
-	 * If the position is not specified, the image will be inserted into the current selection.
-	 * Note: You can use the {@link module:widget/utils~findOptimalInsertionPosition} function
-	 * to calculate (e.g. based on the current selection) a position which is more optimal from the UX perspective.
 	 */
 	execute( options ) {
 		const editor = this.editor;
@@ -48,7 +42,7 @@ export default class ImageUploadCommand extends Command {
 			const filesToUpload = Array.isArray( options.files ) ? options.files : [ options.files ];
 
 			for ( const file of filesToUpload ) {
-				uploadImage( writer, editor, file, options.insertAt );
+				uploadImage( writer, editor, file );
 			}
 		} );
 	}
@@ -59,8 +53,7 @@ export default class ImageUploadCommand extends Command {
 // @param {module:engine/model/writer~writer} writer
 // @param {module:core/editor/editor~Editor} editor
 // @param {File} file
-// @param {module:engine/model/position~Position} insertAt
-function uploadImage( writer, editor, file, insertAt ) {
+function uploadImage( writer, editor, file ) {
 	const doc = editor.model.document;
 	const fileRepository = editor.plugins.get( FileRepository );
 
@@ -71,17 +64,9 @@ function uploadImage( writer, editor, file, insertAt ) {
 		return;
 	}
 
-	const imageElement = writer.createElement( 'image', {
-		uploadId: loader.id
-	} );
+	const imageElement = writer.createElement( 'image', { uploadId: loader.id } );
 
-	let insertAtSelection;
-
-	if ( insertAt ) {
-		insertAtSelection = new ModelSelection( [ new ModelRange( insertAt ) ] );
-	} else {
-		insertAtSelection = findOptimalInsertionPosition( doc.selection );
-	}
+	const insertAtSelection = findOptimalInsertionPosition( doc.selection );
 
 	editor.model.insertContent( imageElement, insertAtSelection );
 

--- a/src/imageupload/imageuploadui.js
+++ b/src/imageupload/imageuploadui.js
@@ -46,12 +46,12 @@ export default class ImageUploadUI extends Plugin {
 			view.buttonView.bind( 'isEnabled' ).to( command );
 
 			view.on( 'done', ( evt, files ) => {
-				for ( const file of Array.from( files ) ) {
+				const imagesToUpload = Array.from( files ).filter( isImageType );
+
+				if ( imagesToUpload.length ) {
 					const insertAt = findOptimalInsertionPosition( editor.model.document.selection );
 
-					if ( isImageType( file ) ) {
-						editor.execute( 'imageUpload', { file, insertAt } );
-					}
+					editor.execute( 'imageUpload', { file: imagesToUpload, insertAt } );
 				}
 			} );
 

--- a/src/imageupload/imageuploadui.js
+++ b/src/imageupload/imageuploadui.js
@@ -54,7 +54,7 @@ export default class ImageUploadUI extends Plugin {
 				if ( imagesToUpload.length ) {
 					const insertAt = findOptimalInsertionPosition( editor.model.document.selection );
 
-					editor.execute( 'imageUpload', { file: imagesToUpload, insertAt } );
+					editor.execute( 'imageUpload', { files: imagesToUpload, insertAt } );
 				}
 			} );
 

--- a/src/imageupload/imageuploadui.js
+++ b/src/imageupload/imageuploadui.js
@@ -11,7 +11,6 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import FileDialogButtonView from '@ckeditor/ckeditor5-upload/src/ui/filedialogbuttonview';
 import imageIcon from '@ckeditor/ckeditor5-core/theme/icons/image.svg';
 import { isImageType } from './utils';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * The image upload button plugin.
@@ -52,9 +51,7 @@ export default class ImageUploadUI extends Plugin {
 				const imagesToUpload = Array.from( files ).filter( isImageType );
 
 				if ( imagesToUpload.length ) {
-					const insertAt = findOptimalInsertionPosition( editor.model.document.selection );
-
-					editor.execute( 'imageUpload', { files: imagesToUpload, insertAt } );
+					editor.execute( 'imageUpload', { files: imagesToUpload } );
 				}
 			} );
 

--- a/tests/imageupload/imageuploadcommand.js
+++ b/tests/imageupload/imageuploadcommand.js
@@ -15,14 +15,13 @@ import { setData as setModelData, getData as getModelData } from '@ckeditor/cked
 import Image from '../../src/image/imageediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import { downcastElementToElement } from '@ckeditor/ckeditor5-engine/src/conversion/downcast-converters';
-import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 
 import log from '@ckeditor/ckeditor5-utils/src/log';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'ImageUploadCommand', () => {
-	let editor, command, model, doc, fileRepository;
+	let editor, command, model, fileRepository;
 
 	testUtils.createSinonSandbox();
 
@@ -43,7 +42,6 @@ describe( 'ImageUploadCommand', () => {
 			.then( newEditor => {
 				editor = newEditor;
 				model = editor.model;
-				doc = model.document;
 
 				command = new ImageUploadCommand( editor );
 
@@ -129,19 +127,6 @@ describe( 'ImageUploadCommand', () => {
 			const id = fileRepository.getLoader( file ).id;
 			expect( getModelData( model ) )
 				.to.equal( `[<image uploadId="${ id }"></image>]<paragraph>foo</paragraph>` );
-		} );
-
-		it( 'should insert directly at specified position (options.insertAt)', () => {
-			const file = createNativeFileMock();
-			setModelData( model, '<paragraph>f[]oo</paragraph>' );
-
-			const insertAt = new ModelPosition( doc.getRoot(), [ 0, 2 ] ); // fo[]o
-
-			command.execute( { files: file, insertAt } );
-
-			const id = fileRepository.getLoader( file ).id;
-			expect( getModelData( model ) )
-				.to.equal( `<paragraph>fo</paragraph>[<image uploadId="${ id }"></image>]<paragraph>o</paragraph>` );
 		} );
 
 		it( 'should use parent batch', () => {

--- a/tests/imageupload/imageuploadcommand.js
+++ b/tests/imageupload/imageuploadcommand.js
@@ -56,6 +56,39 @@ describe( 'ImageUploadCommand', () => {
 		return editor.destroy();
 	} );
 
+	describe( 'isEnabled', () => {
+		it( 'should be true when the selection directly in the root', () => {
+			setModelData( model, '[]' );
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be true when the selection directly in a paragraph', () => {
+			setModelData( model, '<paragraph>foo[]</paragraph>' );
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be true when the selection directly in a block', () => {
+			model.schema.register( 'block', { inheritAllFrom: '$block' } );
+			model.schema.extend( '$text', { allowIn: 'block' } );
+			editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'block', view: 'block' } ) );
+
+			setModelData( model, '<block>foo[]</block>' );
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be false when the selection in a limit element', () => {
+			model.schema.register( 'block', { inheritAllFrom: '$block' } );
+			model.schema.register( 'limit', { allowIn: 'block', isLimit: true } );
+			model.schema.extend( '$text', { allowIn: 'limit' } );
+
+			editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'block', view: 'block' } ) );
+			editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'limit', view: 'limit' } ) );
+
+			setModelData( model, '<block><limit>foo[]</limit></block>' );
+			expect( command.isEnabled ).to.be.false;
+		} );
+	} );
+
 	describe( 'execute()', () => {
 		it( 'should insert image at selection position (includes deleting selected content)', () => {
 			const file = createNativeFileMock();

--- a/tests/imageupload/imageuploadcommand.js
+++ b/tests/imageupload/imageuploadcommand.js
@@ -94,7 +94,7 @@ describe( 'ImageUploadCommand', () => {
 			const file = createNativeFileMock();
 			setModelData( model, '<paragraph>f[o]o</paragraph>' );
 
-			command.execute( { file } );
+			command.execute( { files: file } );
 
 			const id = fileRepository.getLoader( file ).id;
 			expect( getModelData( model ) )
@@ -107,7 +107,7 @@ describe( 'ImageUploadCommand', () => {
 
 			const insertAt = new ModelPosition( doc.getRoot(), [ 0, 2 ] ); // fo[]o
 
-			command.execute( { file, insertAt } );
+			command.execute( { files: file, insertAt } );
 
 			const id = fileRepository.getLoader( file ).id;
 			expect( getModelData( model ) )
@@ -122,7 +122,7 @@ describe( 'ImageUploadCommand', () => {
 			model.change( writer => {
 				expect( writer.batch.operations ).to.length( 0 );
 
-				command.execute( { file } );
+				command.execute( { files: file } );
 
 				expect( writer.batch.operations ).to.length.above( 0 );
 			} );
@@ -141,7 +141,7 @@ describe( 'ImageUploadCommand', () => {
 
 			setModelData( model, '<other>[]</other>' );
 
-			command.execute( { file } );
+			command.execute( { files: file } );
 
 			expect( getModelData( model ) ).to.equal( '<other>[]</other>' );
 		} );
@@ -156,7 +156,7 @@ describe( 'ImageUploadCommand', () => {
 			setModelData( model, '<paragraph>fo[]o</paragraph>' );
 
 			expect( () => {
-				command.execute( { file } );
+				command.execute( { files: file } );
 			} ).to.not.throw();
 
 			expect( getModelData( model ) ).to.equal( '<paragraph>fo[]o</paragraph>' );

--- a/tests/imageupload/imageuploadcommand.js
+++ b/tests/imageupload/imageuploadcommand.js
@@ -100,6 +100,23 @@ describe( 'ImageUploadCommand', () => {
 			expect( command.isEnabled ).to.be.false;
 		} );
 
+		it( 'should be false when the selection is on other object', () => {
+			model.schema.register( 'object', { isObject: true, allowIn: '$root' } );
+			editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'object', view: 'object' } ) );
+			setModelData( model, '[<object></object>]' );
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+
+		it( 'should be false when the selection is inside other object', () => {
+			model.schema.register( 'object', { isObject: true, allowIn: '$root' } );
+			model.schema.extend( '$text', { allowIn: 'object' } );
+			editor.conversion.for( 'downcast' ).add( downcastElementToElement( { model: 'object', view: 'object' } ) );
+			setModelData( model, '<object>[]</object>' );
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+
 		it( 'should be false when schema disallows image', () => {
 			model.schema.register( 'block', { inheritAllFrom: '$block' } );
 			model.schema.extend( 'paragraph', { allowIn: 'block' } );

--- a/tests/imageupload/imageuploadediting.js
+++ b/tests/imageupload/imageuploadediting.js
@@ -300,7 +300,7 @@ describe( 'ImageUploadEditing', () => {
 	it( 'should use read data once it is present', done => {
 		const file = createNativeFileMock();
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		model.once( '_change', () => {
 			expect( getViewData( view ) ).to.equal(
@@ -320,7 +320,7 @@ describe( 'ImageUploadEditing', () => {
 	it( 'should replace read data with server response once it is present', done => {
 		const file = createNativeFileMock();
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
@@ -351,7 +351,7 @@ describe( 'ImageUploadEditing', () => {
 		}, { priority: 'high' } );
 
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		nativeReaderMock.mockError( 'Reading error.' );
 	} );
@@ -367,7 +367,7 @@ describe( 'ImageUploadEditing', () => {
 		}, { priority: 'high' } );
 
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 		nativeReaderMock.abort();
 
 		setTimeout( () => {
@@ -391,7 +391,7 @@ describe( 'ImageUploadEditing', () => {
 		} );
 
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		sinon.assert.calledOnce( loadSpy );
 
@@ -428,7 +428,7 @@ describe( 'ImageUploadEditing', () => {
 			evt.stop();
 		}, { priority: 'high' } );
 
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
@@ -445,7 +445,7 @@ describe( 'ImageUploadEditing', () => {
 	it( 'should abort upload if image is removed', () => {
 		const file = createNativeFileMock();
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		const abortSpy = testUtils.sinon.spy( loader, 'abort' );
 
@@ -464,7 +464,7 @@ describe( 'ImageUploadEditing', () => {
 	it( 'should not abort and not restart upload when image is moved', () => {
 		const file = createNativeFileMock();
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		const abortSpy = testUtils.sinon.spy( loader, 'abort' );
 		const loadSpy = testUtils.sinon.spy( loader, 'read' );
@@ -489,7 +489,7 @@ describe( 'ImageUploadEditing', () => {
 			evt.stop();
 		}, { priority: 'high' } );
 
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		model.document.once( 'change', () => {
 			// This is called after "manual" remove.
@@ -525,7 +525,7 @@ describe( 'ImageUploadEditing', () => {
 	it( 'should create responsive image if server return multiple images', done => {
 		const file = createNativeFileMock();
 		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
-		editor.execute( 'imageUpload', { file } );
+		editor.execute( 'imageUpload', { files: file } );
 
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {

--- a/tests/imageupload/imageuploadediting.js
+++ b/tests/imageupload/imageuploadediting.js
@@ -137,27 +137,23 @@ describe( 'ImageUploadEditing', () => {
 	} );
 
 	it( 'should insert image when is pasted on allowed position when ImageUploadCommand is disabled', () => {
+		setModelData( model, '<paragraph>foo</paragraph>[<image></image>]' );
+
 		const fileMock = createNativeFileMock();
 		const dataTransfer = new DataTransfer( { files: [ fileMock ], types: [ 'Files' ] } );
-		setModelData( model, '<paragraph>[]foo</paragraph>' );
 
 		const command = editor.commands.get( 'imageUpload' );
 
-		command.on( 'set:isEnabled', evt => {
-			evt.return = false;
-			evt.stop();
-		}, { priority: 'highest' } );
+		expect( command.isEnabled ).to.be.false;
 
-		command.isEnabled = false;
-
-		const targetRange = Range.createFromParentsAndOffsets( doc.getRoot(), 1, doc.getRoot(), 1 );
+		const targetRange = Range.createFromParentsAndOffsets( doc.getRoot(), 0, doc.getRoot(), 0 );
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
 		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
 
 		const id = fileRepository.getLoader( fileMock ).id;
 		expect( getModelData( model ) ).to.equal(
-			`<paragraph>foo</paragraph>[<image uploadId="${ id }" uploadStatus="reading"></image>]`
+			`[<image uploadId="${ id }" uploadStatus="reading"></image>]<paragraph>foo</paragraph><image></image>`
 		);
 	} );
 
@@ -258,7 +254,7 @@ describe( 'ImageUploadEditing', () => {
 			viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
 		} ).to.not.throw();
 
-		expect( getModelData( model ) ).to.equal( '<paragraph>[]foo</paragraph>' );
+		expect( getModelData( model ) ).to.equal( '<paragraph>foo[]</paragraph>' );
 		sinon.assert.calledOnce( logStub );
 	} );
 

--- a/tests/imageupload/imageuploadprogress.js
+++ b/tests/imageupload/imageuploadprogress.js
@@ -74,7 +74,7 @@ describe( 'ImageUploadProgress', () => {
 
 	it( 'should convert image\'s "reading" uploadStatus attribute', () => {
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
 			'[<figure class="ck-appear ck-image-upload-placeholder ck-widget image" contenteditable="false">' +
@@ -86,7 +86,7 @@ describe( 'ImageUploadProgress', () => {
 
 	it( 'should convert image\'s "uploading" uploadStatus attribute', done => {
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		model.document.once( 'change', () => {
 			expect( getViewData( view ) ).to.equal(
@@ -167,7 +167,7 @@ describe( 'ImageUploadProgress', () => {
 
 	it( 'should update progressbar width on progress', done => {
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		model.document.once( 'change', () => {
 			adapterMock.mockProgress( 40, 100 );
@@ -189,7 +189,7 @@ describe( 'ImageUploadProgress', () => {
 		const clock = testUtils.sinon.useFakeTimers();
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {
@@ -222,7 +222,7 @@ describe( 'ImageUploadProgress', () => {
 		uploadProgress.placeholder = base64Sample;
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
 			'[<figure class="ck-appear ck-image-upload-placeholder ck-widget image" contenteditable="false">' +
@@ -238,7 +238,7 @@ describe( 'ImageUploadProgress', () => {
 		}, { priority: 'highest' } );
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		expect( getViewData( view ) ).to.equal(
 			'[<figure class="ck-widget image" contenteditable="false"><img></img></figure>]<p>foo</p>'
@@ -276,7 +276,7 @@ describe( 'ImageUploadProgress', () => {
 		testUtils.sinon.stub( env, 'isEdge' ).get( () => true );
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );
-		editor.execute( 'imageUpload', { file: createNativeFileMock() } );
+		editor.execute( 'imageUpload', { files: createNativeFileMock() } );
 
 		model.document.once( 'change', () => {
 			model.document.once( 'change', () => {

--- a/tests/imageupload/imageuploadui.js
+++ b/tests/imageupload/imageuploadui.js
@@ -99,7 +99,18 @@ describe( 'ImageUploadUI', () => {
 		button.fire( 'done', files );
 		sinon.assert.calledOnce( executeStub );
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
-		expect( executeStub.firstCall.args[ 1 ].file ).to.equal( files[ 0 ] );
+		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( files );
+	} );
+
+	it( 'should execute imageUpload command with multiple files', () => {
+		const executeStub = sinon.stub( editor, 'execute' );
+		const button = editor.ui.componentFactory.create( 'imageUpload' );
+		const files = [ createNativeFileMock(), createNativeFileMock(), createNativeFileMock() ];
+
+		button.fire( 'done', files );
+		sinon.assert.calledOnce( executeStub );
+		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
+		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( files );
 	} );
 
 	it( 'should optimize the insertion position', () => {
@@ -131,8 +142,8 @@ describe( 'ImageUploadUI', () => {
 
 		expect( getModelData( model ) ).to.equal(
 			'<paragraph>foo</paragraph>' +
-			`<image uploadId="${ id1 }" uploadStatus="reading"></image>` +
-			`[<image uploadId="${ id2 }" uploadStatus="reading"></image>]` +
+			`[<image uploadId="${ id1 }" uploadStatus="reading"></image>]` +
+			`<image uploadId="${ id2 }" uploadStatus="reading"></image>` +
 			'<paragraph>bar</paragraph>'
 		);
 	} );
@@ -160,6 +171,6 @@ describe( 'ImageUploadUI', () => {
 		button.fire( 'done', files );
 		sinon.assert.calledOnce( executeStub );
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
-		expect( executeStub.firstCall.args[ 1 ].file ).to.equal( files[ 0 ] );
+		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( [ files[ 0 ] ] );
 	} );
 } );

--- a/tests/imageupload/imageuploadui.js
+++ b/tests/imageupload/imageuploadui.js
@@ -99,7 +99,7 @@ describe( 'ImageUploadUI', () => {
 		button.fire( 'done', files );
 		sinon.assert.calledOnce( executeStub );
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
-		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( files );
+		expect( executeStub.firstCall.args[ 1 ].files ).to.deep.equal( files );
 	} );
 
 	it( 'should execute imageUpload command with multiple files', () => {
@@ -110,7 +110,7 @@ describe( 'ImageUploadUI', () => {
 		button.fire( 'done', files );
 		sinon.assert.calledOnce( executeStub );
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
-		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( files );
+		expect( executeStub.firstCall.args[ 1 ].files ).to.deep.equal( files );
 	} );
 
 	it( 'should optimize the insertion position', () => {
@@ -171,6 +171,6 @@ describe( 'ImageUploadUI', () => {
 		button.fire( 'done', files );
 		sinon.assert.calledOnce( executeStub );
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
-		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( [ files[ 0 ] ] );
+		expect( executeStub.firstCall.args[ 1 ].files ).to.deep.equal( [ files[ 0 ] ] );
 	} );
 } );

--- a/tests/imageupload/imageuploadui.js
+++ b/tests/imageupload/imageuploadui.js
@@ -142,8 +142,8 @@ describe( 'ImageUploadUI', () => {
 
 		expect( getModelData( model ) ).to.equal(
 			'<paragraph>foo</paragraph>' +
-			`[<image uploadId="${ id1 }" uploadStatus="reading"></image>]` +
-			`<image uploadId="${ id2 }" uploadStatus="reading"></image>` +
+			`<image uploadId="${ id1 }" uploadStatus="reading"></image>` +
+			`[<image uploadId="${ id2 }" uploadStatus="reading"></image>]` +
 			'<paragraph>bar</paragraph>'
 		);
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `ImageUploadCommand` should check whether it can be executed in the selection context. Closes ckeditor/ckeditor5#5158. Closes ckeditor/ckeditor5#5160. Closes ckeditor/ckeditor5#5163.

BREAKING CHANGE: The `options.file` property was renamed to `options.files` for `'imageUpload'` command.
BREAKING CHANGE: The `options.insertAt` property for `'imageUpload'` command was removed. The command will use model's selection.