### PR TITLE
t/ckeditor5/1348: Used the getViewportTopOffsetConfig helper in the code snippets.

### DIFF
--- a/docs/_snippets/features/image-caption.js
+++ b/docs/_snippets/features/image-caption.js
@@ -14,7 +14,7 @@ ClassicEditor
 			toolbar: [ 'imageTextAlternative' ]
 		},
 		toolbar: {
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/features/image-style-custom.js
+++ b/docs/_snippets/features/image-style-custom.js
@@ -24,7 +24,7 @@ ClassicEditor
 			toolbar: [ 'imageTextAlternative', '|', 'imageStyle:alignLeft', 'imageStyle:full', 'imageStyle:alignRight' ]
 		},
 		toolbar: {
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/features/image-style.js
+++ b/docs/_snippets/features/image-style.js
@@ -10,7 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-style' ), {
 		toolbar: {
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/features/image-toolbar.js
+++ b/docs/_snippets/features/image-toolbar.js
@@ -14,7 +14,7 @@ ClassicEditor
 			toolbar: [ 'imageTextAlternative' ]
 		},
 		toolbar: {
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/features/image.js
+++ b/docs/_snippets/features/image.js
@@ -11,7 +11,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-image' ), {
 		removePlugins: [ 'ImageToolbar', 'ImageCaption', 'ImageStyle' ],
 		toolbar: {
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		cloudServices: CS_CONFIG
 	} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the `getViewportTopOffsetConfig` helper in the code snippets to make sure the toolbar top offset is correct regardless of the page layout (see ckeditor/ckeditor5#1348).

---

### Additional information

This PR is a piece of the https://github.com/ckeditor/ckeditor5/pull/1360 constellation.
