### PR TITLE
Use entire data object when re-firing `inputTransformation` event

### DIFF
--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -129,10 +129,7 @@ export default class ImageUploadEditing extends Plugin {
 					}
 				}
 
-				editor.plugins.get( 'Clipboard' ).fire( 'inputTransformation', {
-					content: data.content,
-					dataTransfer: data.dataTransfer
-				} );
+				editor.plugins.get( 'Clipboard' ).fire( 'inputTransformation', data );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use entire data object when re-firing `inputTransformation` event.

---

### Additional information

See https://github.com/ckeditor/ckeditor5-paste-from-office/pull/47.
