### PR TITLE
Remove ImageEditing from requires method of ImageStyleEditing.

### DIFF
--- a/src/imagestyle/imagestyleediting.js
+++ b/src/imagestyle/imagestyleediting.js
@@ -9,7 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ImageStyleCommand from './imagestylecommand';
-import ImageEditing from '../image/imageediting';
 import { viewToModelStyleAttribute, modelToViewStyleAttribute } from './converters';
 import { normalizeImageStyles } from './utils';
 
@@ -20,13 +19,6 @@ import { normalizeImageStyles } from './utils';
  * @extends {module:core/plugin~Plugin}
  */
 export default class ImageStyleEditing extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ ImageEditing ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/tests/imagestyle.js
+++ b/tests/imagestyle.js
@@ -4,6 +4,7 @@
  */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Image from '../src/image';
 import ImageStyle from '../src/imagestyle';
 import ImageStyleEditing from '../src/imagestyle/imagestyleediting';
 import ImageStyleUI from '../src/imagestyle/imagestyleui';
@@ -18,7 +19,7 @@ describe( 'ImageStyle', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ ImageStyle ]
+				plugins: [ Image, ImageStyle ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;

--- a/tests/imagestyle/imagestyleediting.js
+++ b/tests/imagestyle/imagestyleediting.js
@@ -32,7 +32,7 @@ describe( 'ImageStyleEditing', () => {
 		beforeEach( () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ],
+					plugins: [ ImageEditing, ImageStyleEditing ]
 				} )
 				.then( newEditor => {
 					editor = newEditor;
@@ -42,17 +42,13 @@ describe( 'ImageStyleEditing', () => {
 		it( 'should be loaded', () => {
 			expect( editor.plugins.get( ImageStyleEditing ) ).to.be.instanceOf( ImageStyleEditing );
 		} );
-
-		it( 'should load image editing', () => {
-			expect( editor.plugins.get( ImageEditing ) ).to.be.instanceOf( ImageEditing );
-		} );
 	} );
 
 	describe( 'init', () => {
 		beforeEach( () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ],
+					plugins: [ ImageEditing, ImageStyleEditing ],
 					image: {
 						styles: [
 							{ name: 'fullStyle', title: 'foo', icon: 'object-center', isDefault: true },
@@ -72,7 +68,7 @@ describe( 'ImageStyleEditing', () => {
 		it( 'should define image.styles config', () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ]
+					plugins: [ ImageEditing, ImageStyleEditing ]
 				} )
 				.then( newEditor => {
 					editor = newEditor;
@@ -265,7 +261,7 @@ describe( 'ImageStyleEditing', () => {
 		it( 'should fall back to defaults when no image.styles', () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ]
+					plugins: [ ImageEditing, ImageStyleEditing ]
 				} )
 				.then( newEditor => {
 					editor = newEditor;
@@ -277,7 +273,7 @@ describe( 'ImageStyleEditing', () => {
 		it( 'should not alter the image.styles config', () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ],
+					plugins: [ ImageEditing, ImageStyleEditing ],
 					image: {
 						styles: [
 							'side'
@@ -294,7 +290,7 @@ describe( 'ImageStyleEditing', () => {
 		it( 'should not alter object definitions in the image.styles config', () => {
 			return VirtualTestEditor
 				.create( {
-					plugins: [ ImageStyleEditing ],
+					plugins: [ ImageEditing, ImageStyleEditing ],
 					image: {
 						styles: [
 							{ name: 'side' }

--- a/tests/imagestyle/imagestyleui.js
+++ b/tests/imagestyle/imagestyleui.js
@@ -6,6 +6,7 @@
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import ImageStyleEditing from '../../src/imagestyle/imagestyleediting';
 import ImageStyleUI from '../../src/imagestyle/imagestyleui';
+import ImageEditing from '../../src/image/imageediting';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
@@ -26,7 +27,7 @@ describe( 'ImageStyleUI', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ ImageStyleEditing, ImageStyleUI ],
+				plugins: [ ImageEditing, ImageStyleEditing, ImageStyleUI ],
 				image: {
 					styles
 				}
@@ -77,7 +78,7 @@ describe( 'ImageStyleUI', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ TranslationMock, ImageStyleEditing, ImageStyleUI ],
+				plugins: [ TranslationMock, ImageEditing, ImageStyleEditing, ImageStyleUI ],
 				image: {
 					styles: [
 						{ name: 'style 1', title: 'Side image', icon: 'style1-icon', isDefault: true }
@@ -99,7 +100,7 @@ describe( 'ImageStyleUI', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ ImageStyleEditing, ImageStyleUI ],
+				plugins: [ ImageEditing, ImageStyleEditing, ImageStyleUI ],
 				image: {
 					styles,
 					toolbar: [ 'foo', 'bar' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove ImageEditing plugin from requires method of ImageStyleEditing. Closes ckeditor/ckeditor5#5176.

---

### Additional information
