### PR TITLE
t/ckeditor5-widget/60:  Aligned to the new `WidgetToolbarRepository` API

### DIFF
--- a/src/image/ui/utils.js
+++ b/src/image/ui/utils.js
@@ -8,7 +8,7 @@
  */
 
 import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpanelview';
-import { isImageWidgetSelected } from '../utils';
+import { getSelectedImageWidget } from '../utils';
 
 /**
  * A helper utility that positions the
@@ -20,7 +20,7 @@ import { isImageWidgetSelected } from '../utils';
 export function repositionContextualBalloon( editor ) {
 	const balloon = editor.plugins.get( 'ContextualBalloon' );
 
-	if ( isImageWidgetSelected( editor.editing.view.document.selection ) ) {
+	if ( getSelectedImageWidget( editor.editing.view.document.selection ) ) {
 		const position = getBalloonPositionData( editor );
 
 		balloon.updatePosition( position );

--- a/src/image/utils.js
+++ b/src/image/utils.js
@@ -45,15 +45,19 @@ export function isImageWidget( viewElement ) {
 }
 
 /**
- * Checks if an image widget is the only selected element.
+ * Returns an image widget editing view element if one is selected.
  *
  * @param {module:engine/view/selection~Selection|module:engine/view/documentselection~DocumentSelection} selection
- * @returns {Boolean}
+ * @returns {module:engine/view/element~Element|null}
  */
-export function isImageWidgetSelected( selection ) {
+export function getSelectedImageWidget( selection ) {
 	const viewElement = selection.getSelectedElement();
 
-	return !!( viewElement && isImageWidget( viewElement ) );
+	if ( viewElement && isImageWidget( viewElement ) ) {
+		return viewElement;
+	}
+
+	return null;
 }
 
 /**

--- a/src/imagetextalternative/imagetextalternativeui.js
+++ b/src/imagetextalternative/imagetextalternativeui.js
@@ -14,7 +14,7 @@ import TextAlternativeFormView from './ui/textalternativeformview';
 import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextualballoon';
 import textAlternativeIcon from '@ckeditor/ckeditor5-core/theme/icons/low-vision.svg';
 import { repositionContextualBalloon, getBalloonPositionData } from '../image/ui/utils';
-import { isImageWidgetSelected } from '../image/utils';
+import { getSelectedImageWidget } from '../image/utils';
 
 /**
  * The image text alternative UI plugin.
@@ -116,7 +116,7 @@ export default class ImageTextAlternativeUI extends Plugin {
 
 		// Reposition the balloon or hide the form if an image widget is no longer selected.
 		this.listenTo( editor.ui, 'update', () => {
-			if ( !isImageWidgetSelected( viewDocument.selection ) ) {
+			if ( !getSelectedImageWidget( viewDocument.selection ) ) {
 				this._hideForm( true );
 			} else if ( this._isVisible ) {
 				repositionContextualBalloon( editor );

--- a/src/imagetoolbar.js
+++ b/src/imagetoolbar.js
@@ -8,7 +8,7 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import { isImageWidgetSelected } from './image/utils';
+import { getSelectedImageWidget } from './image/utils';
 import WidgetToolbarRepository from '@ckeditor/ckeditor5-widget/src/widgettoolbarrepository';
 
 /**
@@ -48,7 +48,7 @@ export default class ImageToolbar extends Plugin {
 
 		widgetToolbarRepository.register( 'image', {
 			items: editor.config.get( 'image.toolbar' ) || [],
-			visibleWhen: isImageWidgetSelected,
+			getRelatedElement: getSelectedImageWidget,
 		} );
 	}
 }

--- a/tests/image/utils.js
+++ b/tests/image/utils.js
@@ -7,7 +7,7 @@ import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfr
 import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
 import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
-import { toImageWidget, isImageWidget, isImageWidgetSelected, isImage, isImageAllowed, insertImage } from '../../src/image/utils';
+import { toImageWidget, isImageWidget, getSelectedImageWidget, isImage, isImageAllowed, insertImage } from '../../src/image/utils';
 import { isWidget, getLabel } from '@ckeditor/ckeditor5-widget/src/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
@@ -57,7 +57,7 @@ describe( 'image widget utils', () => {
 		} );
 	} );
 
-	describe( 'isImageWidgetSelected()', () => {
+	describe( 'getSelectedImageWidget()', () => {
 		let frag;
 
 		it( 'should return true when image widget is the only element in the selection', () => {
@@ -66,7 +66,7 @@ describe( 'image widget utils', () => {
 
 			const selection = writer.createSelection( element, 'on' );
 
-			expect( isImageWidgetSelected( selection ) ).to.be.true;
+			expect( getSelectedImageWidget( selection ) ).to.equal( element );
 		} );
 
 		it( 'should return false when non-widgetized elements is the only element in the selection', () => {
@@ -77,7 +77,7 @@ describe( 'image widget utils', () => {
 
 			const selection = writer.createSelection( notWidgetizedElement, 'on' );
 
-			expect( isImageWidgetSelected( selection ) ).to.be.false;
+			expect( getSelectedImageWidget( selection ) ).to.be.null;
 		} );
 
 		it( 'should return false when widget element is not the only element in the selection', () => {
@@ -87,7 +87,7 @@ describe( 'image widget utils', () => {
 
 			const selection = writer.createSelection( writer.createRangeIn( frag ) );
 
-			expect( isImageWidgetSelected( selection ) ).to.be.false;
+			expect( getSelectedImageWidget( selection ) ).to.be.null;
 		} );
 	} );
 

--- a/tests/imagetoolbar.js
+++ b/tests/imagetoolbar.js
@@ -41,7 +41,7 @@ describe( 'ImageToolbar', () => {
 				model = newEditor.model;
 				doc = model.document;
 				widgetToolbarRepository = editor.plugins.get( 'WidgetToolbarRepository' );
-				toolbar = widgetToolbarRepository._toolbars.get( 'image' ).view;
+				toolbar = widgetToolbarRepository._toolbarDefinitions.get( 'image' ).view;
 				balloon = editor.plugins.get( 'ContextualBalloon' );
 			} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other:  Aligned to the new `WidgetToolbarRepository` API. Replaced the `isImageWidgetSelected()` utility with `getSelectedImageWidget()` (see ckeditor/ckeditor5#4595).

BREAKING CHANGE: The `isImageWidgetSelected()` utility has been replaced by `getSelectedImageWidget()` and returns an editing `View` element instead of `Boolean`.

---

Part of https://github.com/ckeditor/ckeditor5-widget/pull/64.