### PR TITLE
t/ckeditor5/1520b: Got rid of the Symbols used to recognize view elements; replaced with strings

### DIFF
--- a/src/image/utils.js
+++ b/src/image/utils.js
@@ -9,8 +9,6 @@
 
 import { findOptimalInsertionPosition, isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 
-const imageSymbol = Symbol( 'isImage' );
-
 /**
  * Converts a given {@link module:engine/view/element~Element} to an image widget:
  * * Adds a {@link module:engine/view/element~Element#_setCustomProperty custom property} allowing to recognize the image widget element.
@@ -22,7 +20,7 @@ const imageSymbol = Symbol( 'isImage' );
  * @returns {module:engine/view/element~Element}
  */
 export function toImageWidget( viewElement, writer, label ) {
-	writer.setCustomProperty( imageSymbol, true, viewElement );
+	writer.setCustomProperty( 'image', true, viewElement );
 
 	return toWidget( viewElement, writer, { label: labelCreator } );
 
@@ -41,7 +39,7 @@ export function toImageWidget( viewElement, writer, label ) {
  * @returns {Boolean}
  */
 export function isImageWidget( viewElement ) {
-	return !!viewElement.getCustomProperty( imageSymbol ) && isWidget( viewElement );
+	return !!viewElement.getCustomProperty( 'image' ) && isWidget( viewElement );
 }
 
 /**

--- a/src/imagecaption/utils.js
+++ b/src/imagecaption/utils.js
@@ -10,8 +10,6 @@
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 import { toWidgetEditable } from '@ckeditor/ckeditor5-widget/src/utils';
 
-const captionSymbol = Symbol( 'imageCaption' );
-
 /**
  * Returns a function that creates a caption editable element for the given {@link module:engine/view/document~Document}.
  *
@@ -22,7 +20,7 @@ const captionSymbol = Symbol( 'imageCaption' );
 export function captionElementCreator( view, placeholderText ) {
 	return writer => {
 		const editable = writer.createEditableElement( 'figcaption' );
-		writer.setCustomProperty( captionSymbol, true, editable );
+		writer.setCustomProperty( 'imageCaption', true, editable );
 
 		enablePlaceholder( {
 			view,
@@ -41,7 +39,7 @@ export function captionElementCreator( view, placeholderText ) {
  * @returns {Boolean}
  */
 export function isCaption( viewElement ) {
-	return !!viewElement.getCustomProperty( captionSymbol );
+	return !!viewElement.getCustomProperty( 'imageCaption' );
 }
 
 /**

--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -114,12 +114,6 @@ export default class ImageUploadProgress extends Plugin {
 	}
 }
 
-// Symbol added to progress bar UIElement to distinguish it from other elements.
-const progressBarSymbol = Symbol( 'progress-bar' );
-
-// Symbol added to placeholder UIElement to distinguish it from other elements.
-const placeholderSymbol = Symbol( 'placeholder' );
-
 // Adds ck-appear class to the image figure if one is not already applied.
 //
 // @param {module:engine/view/containerelement~ContainerElement} viewFigure
@@ -154,7 +148,7 @@ function _showPlaceholder( placeholder, viewFigure, writer ) {
 		writer.setAttribute( 'src', placeholder, viewImg );
 	}
 
-	if ( !_getUIElement( viewFigure, placeholderSymbol ) ) {
+	if ( !_getUIElement( viewFigure, 'placeholder' ) ) {
 		writer.insert( writer.createPositionAfter( viewImg ), _createPlaceholder( writer ) );
 	}
 }
@@ -168,7 +162,7 @@ function _hidePlaceholder( viewFigure, writer ) {
 		writer.removeClass( 'ck-image-upload-placeholder', viewFigure );
 	}
 
-	_removeUIElement( viewFigure, writer, placeholderSymbol );
+	_removeUIElement( viewFigure, writer, 'placeholder' );
 }
 
 // Shows progress bar displaying upload progress.
@@ -195,7 +189,7 @@ function _showProgressBar( viewFigure, writer, loader, view ) {
 // @param {module:engine/view/containerelement~ContainerElement} viewFigure
 // @param {module:engine/view/downcastwriter~DowncastWriter} writer
 function _hideProgressBar( viewFigure, writer ) {
-	_removeUIElement( viewFigure, writer, progressBarSymbol );
+	_removeUIElement( viewFigure, writer, 'progressBar' );
 }
 
 // Shows complete icon and hides after a certain amount of time.
@@ -221,7 +215,7 @@ function _showCompleteIcon( viewFigure, writer, view ) {
 function _createProgressBar( writer ) {
 	const progressBar = writer.createUIElement( 'div', { class: 'ck-progress-bar' } );
 
-	writer.setCustomProperty( progressBarSymbol, true, progressBar );
+	writer.setCustomProperty( 'progressBar', true, progressBar );
 
 	return progressBar;
 }
@@ -234,7 +228,7 @@ function _createProgressBar( writer ) {
 function _createPlaceholder( writer ) {
 	const placeholder = writer.createUIElement( 'div', { class: 'ck-upload-placeholder-loader' } );
 
-	writer.setCustomProperty( placeholderSymbol, true, placeholder );
+	writer.setCustomProperty( 'placeholder', true, placeholder );
 
 	return placeholder;
 }
@@ -244,7 +238,7 @@ function _createPlaceholder( writer ) {
 //
 // @private
 // @param {module:engine/view/element~Element} imageFigure
-// @param {Symbol} uniqueProperty
+// @param {String} uniqueProperty
 // @returns {module:engine/view/uielement~UIElement|undefined}
 function _getUIElement( imageFigure, uniqueProperty ) {
 	for ( const child of imageFigure.getChildren() ) {
@@ -259,7 +253,7 @@ function _getUIElement( imageFigure, uniqueProperty ) {
 // @private
 // @param {module:engine/view/element~Element} imageFigure
 // @param {module:engine/view/downcastwriter~DowncastWriter} writer
-// @param {Symbol} uniqueProperty
+// @param {String} uniqueProperty
 function _removeUIElement( viewFigure, writer, uniqueProperty ) {
 	const element = _getUIElement( viewFigure, uniqueProperty );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the Symbols used to recognize view elements; replaced with strings (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1532 constellation.
