### PR TITLE
t/ckeditor5/1336: Added names to the plugins that expose a public API

### DIFF
--- a/src/imagestyle/imagestyleui.js
+++ b/src/imagestyle/imagestyleui.js
@@ -21,6 +21,13 @@ import '../../theme/imagestyle.css';
  */
 export default class ImageStyleUI extends Plugin {
 	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'ImageStyleUI';
+	}
+
+	/**
 	 * Returns the default localized style titles provided by the plugin.
 	 *
 	 * The following localized titles corresponding with

--- a/src/imagetextalternative/imagetextalternativeui.js
+++ b/src/imagetextalternative/imagetextalternativeui.js
@@ -34,6 +34,13 @@ export default class ImageTextAlternativeUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
+	static get pluginName() {
+		return 'ImageTextAlternativeUI';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	init() {
 		this._createButton();
 		this._createForm();

--- a/tests/imagestyle/imagestyleui.js
+++ b/tests/imagestyle/imagestyleui.js
@@ -41,6 +41,10 @@ describe( 'ImageStyleUI', () => {
 		return editor.destroy();
 	} );
 
+	it( 'should be named', () => {
+		expect( ImageStyleUI.pluginName ).to.equal( 'ImageStyleUI' );
+	} );
+
 	it( 'should register buttons for each style', () => {
 		const spy = sinon.spy( editor, 'execute' );
 

--- a/tests/imagetextalternative/imagetextalternativeui.js
+++ b/tests/imagetextalternative/imagetextalternativeui.js
@@ -45,6 +45,10 @@ describe( 'ImageTextAlternative', () => {
 		return editor.destroy();
 	} );
 
+	it( 'should be named', () => {
+		expect( ImageTextAlternativeUI.pluginName ).to.equal( 'ImageTextAlternativeUI' );
+	} );
+
 	describe( 'toolbar button', () => {
 		it( 'should be registered in component factory', () => {
 			expect( button ).to.be.instanceOf( ButtonView );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added names to the plugins that expose a public API (see ckeditor/ckeditor5#1336).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/1336.
