### PR TITLE
T/ckeditor5/1524: Insert missing caption for images that are nested in other elements.

### DIFF
--- a/src/imagecaption/imagecaptionediting.js
+++ b/src/imagecaption/imagecaptionediting.js
@@ -185,40 +185,34 @@ export default class ImageCaptionEditing extends Plugin {
 		let wasFixed = false;
 
 		for ( const entry of changes ) {
-			if ( entry.type == 'insert' ) {
-				const images = [];
+			const images = [];
 
+			if ( entry.type == 'insert' && entry.name != '$text' ) {
 				const item = entry.position.nodeAfter;
 
-				if ( item ) {
-					if ( entry.name == 'image' ) {
-						images.push( item );
-					} else {
-						if ( !item.is( 'image' ) && item.childCount ) {
-							const walker = model.createRangeOn( item ).getWalker();
+				if ( item.is( 'image' ) ) {
+					images.push( item );
+				} else if ( item.childCount ) {
+					const walker = model.createRangeOn( item ).getWalker();
 
-							for ( const walkerValue of walker ) {
-								if ( walkerValue.type === 'elementStart' ) {
-									const itemos = walkerValue.item;
+					for ( const walkerValue of walker ) {
+						if ( walkerValue.type === 'elementStart' ) {
+							const walkerItem = walkerValue.item;
 
-									if ( itemos.name === 'image' ) {
-										images.push( itemos );
-									}
-								}
+							if ( walkerItem.is( 'image' ) ) {
+								images.push( walkerItem );
 							}
 						}
 					}
 				}
-
-				for ( const image of images ) {
-					if ( !getCaptionFromImage( image ) ) {
-						writer.appendElement( 'caption', image );
-					}
-				}
-
-				// TODO: infinite loop :/
-				wasFixed = false;
 			}
+
+			for ( const image of images.filter( image => !getCaptionFromImage( image ) ) ) {
+				writer.appendElement( 'caption', image );
+			}
+
+			// TODO: infinite loop :/
+			wasFixed = false;
 		}
 
 		return wasFixed;

--- a/src/imagecaption/imagecaptionediting.js
+++ b/src/imagecaption/imagecaptionediting.js
@@ -190,16 +190,9 @@ export default class ImageCaptionEditing extends Plugin {
 
 				// Check elements with children for nested images.
 				if ( !item.is( 'image' ) && item.childCount ) {
-					// Use the walker to find all nested images despite of their nest level.
-					const walker = model.createRangeOn( item ).getWalker();
-
-					for ( const walkerValue of walker ) {
-						if ( walkerValue.type === 'elementStart' ) {
-							const walkerItem = walkerValue.item;
-
-							if ( walkerItem.is( 'image' ) && !getCaptionFromImage( walkerItem ) ) {
-								imagesWithoutCaption.push( walkerItem );
-							}
+					for ( const nestedItem of model.createRangeIn( item ).getItems() ) {
+						if ( nestedItem.is( 'image' ) && !getCaptionFromImage( nestedItem ) ) {
+							imagesWithoutCaption.push( nestedItem );
 						}
 					}
 				}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Insert missing caption for images that are nested in other elements. Closes ckeditor/ckeditor5#1524.

---

### Additional information

* I've used the TreeWalker to check inserted content for images. I'm not sure if this is optimal but right now I don't a need to introduce anything new to the differ (ie list of inserted child nodes for give `insert` type of change).
