### PR TITLE
Fix: Blur the ImageTextAlternative input before removing it from the DOM.

### DIFF
--- a/src/imagetextalternative/imagetextalternativeui.js
+++ b/src/imagetextalternative/imagetextalternativeui.js
@@ -191,6 +191,10 @@ export default class ImageTextAlternativeUI extends Plugin {
 			return;
 		}
 
+		// Blur the input element before removing it from DOM to prevent issues in some browsers.
+		// See https://github.com/ckeditor/ckeditor5/issues/1501.
+		this._form.saveButtonView.focus();
+
 		this._balloon.remove( this._form );
 
 		if ( focusEditable ) {

--- a/tests/imagetextalternative/imagetextalternativeui.js
+++ b/tests/imagetextalternative/imagetextalternativeui.js
@@ -15,7 +15,7 @@ import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
-describe( 'ImageTextAlternative', () => {
+describe( 'ImageTextAlternativeUI', () => {
 	let editor, model, doc, plugin, command, form, balloon, editorElement, button;
 
 	beforeEach( () => {
@@ -158,6 +158,20 @@ describe( 'ImageTextAlternative', () => {
 
 			button.fire( 'execute' );
 			expect( balloon.visibleView ).to.equal( lastView );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/1501
+		it( 'should blur url input element before hiding the view', () => {
+			setData( model, '[<image src="" alt="foo bar"></image>]' );
+
+			editor.ui.componentFactory.create( 'imageTextAlternative' ).fire( 'execute' );
+
+			const editableFocusSpy = sinon.spy( editor.editing.view, 'focus' );
+			const buttonFocusSpy = sinon.spy( form.saveButtonView, 'focus' );
+
+			form.fire( 'submit' );
+
+			expect( buttonFocusSpy.calledBefore( editableFocusSpy ) ).to.equal( true );
 		} );
 
 		describe( 'integration with the editor selection (ui#update event)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Blur the ImageTextAlternative input before removing it from the DOM. Closes https://github.com/ckeditor/ckeditor5/issues/1501.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
