### PR TITLE
Fix "_rwd.css" import path

### DIFF
--- a/theme/textalternativeform.css
+++ b/theme/textalternativeform.css
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-@import "@ckeditor/ckeditor5-theme-lark/theme/mixins/_rwd.css";
+@import "@ckeditor/ckeditor5-ui/theme/mixins/_rwd.css";
 
 .ck.ck-text-alternative-form {
 	display: flex;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Aligned import paths after moving `_rwd.css` file from `theme-lark` to `ui`. See ckeditor/ckeditor5#1662.