### PR TITLE
Fix: ImageTextAlternative click outside handler scope.

### DIFF
--- a/src/imagetextalternative/imagetextalternativeui.js
+++ b/src/imagetextalternative/imagetextalternativeui.js
@@ -144,7 +144,7 @@ export default class ImageTextAlternativeUI extends Plugin {
 		clickOutsideHandler( {
 			emitter: this._form,
 			activator: () => this._isVisible,
-			contextElements: [ this._form.element ],
+			contextElements: [ this._balloon.view.element ],
 			callback: () => this._hideForm()
 		} );
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: ImageTextAlternative click outside handler scope. Closes ckeditor/ckeditor5#5183.