### PR TITLE
Image widgets should not be forced to consume an entire width

### DIFF
--- a/theme/image.css
+++ b/theme/image.css
@@ -4,11 +4,12 @@
  */
 
 .ck-content .image {
+	display: block;
 	clear: both;
 	text-align: center;
 
-	/* Make sure there is some space between the content and the image. */
-	margin: 1em 0;
+	/* Make sure there is some space between the content and the image. Center image by default. */
+	margin: 1em auto;
 
 	& > img {
 		/* Prevent unnecessary margins caused by line-height (see #44). */

--- a/theme/image.css
+++ b/theme/image.css
@@ -20,5 +20,8 @@
 
 		/* Make sure the image never exceeds the size of the parent container (ckeditor/ckeditor5-ui#67). */
 		max-width: 100%;
+
+		/* Make sure the caption will be displayed properly (See: https://github.com/ckeditor/ckeditor5/issues/1870). */
+		min-width: 50px;
 	}
 }

--- a/theme/image.css
+++ b/theme/image.css
@@ -4,7 +4,7 @@
  */
 
 .ck-content .image {
-	display: block;
+	display: table;
 	clear: both;
 	text-align: center;
 

--- a/theme/imagecaption.css
+++ b/theme/imagecaption.css
@@ -4,6 +4,10 @@
  */
 
 .ck-content .image > figcaption {
+	display: table-caption;
+	caption-side: bottom;
+	word-break: break-word;
+
 	color: hsl(0, 0%, 20%);
 	background-color: hsl(0, 0%, 97%);
 	padding: .6em;

--- a/theme/imagecaption.css
+++ b/theme/imagecaption.css
@@ -7,7 +7,6 @@
 	display: table-caption;
 	caption-side: bottom;
 	word-break: break-word;
-
 	color: hsl(0, 0%, 20%);
 	background-color: hsl(0, 0%, 97%);
 	padding: .6em;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Image widgets should not the entire width of the editor. Closes https://github.com/ckeditor/ckeditor5/issues/1870.

BREAKING CHANGE: From now on, all images use CSS `display: table` by default (`.ck-content .image { display: table }`). This could have an impact on your application and we recommend you to check if images render correctly in CKEditor 5 after this update.

---

### Additional information

<img width="823" alt="Screenshot 2019-07-12 at 13 25 31" src="https://user-images.githubusercontent.com/10219857/61124927-9a32eb00-a4a8-11e9-8c6e-dc055c23df9f.png">
