### PR TITLE
Removed unused --ck-color-upload-infinite-background CSS variable.

### DIFF
--- a/theme/imageuploadprogress.css
+++ b/theme/imageuploadprogress.css
@@ -3,11 +3,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* Infinite progress bar default width. */
-:root {
-	--ck-image-upload-progress-line-width: 30px;
-}
-
 .ck-content .image {
 	position: relative;
 	overflow: hidden;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed unused --ck-color-upload-infinite-background CSS variable. 

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5-theme-lark/pull/240