### PR TITLE
Workaround for Safari's image size bug

### DIFF
--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -197,7 +197,18 @@ export default class ImageUploadEditing extends Plugin {
 				// https://github.com/ckeditor/ckeditor5/issues/1975
 				if ( env.isSafari ) {
 					editor.ui.once( 'update', () => {
+						// Early returns just to be safe. There might be some code ran
+						// in between the outer scope and this callback.
+						if ( !viewImg.parent ) {
+							return;
+						}
+
 						const domFigure = editor.editing.view.domConverter.viewToDom( viewImg.parent );
+
+						if ( !domFigure ) {
+							return;
+						}
+
 						const originalDisplay = domFigure.style.display;
 
 						domFigure.style.display = 'none';

--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -205,8 +205,6 @@ export default class ImageUploadEditing extends Plugin {
 						const offsetHeightBefore = domFigure.offsetHeight; // eslint-disable-line no-unused-vars
 
 						domFigure.style.display = originalDisplay;
-
-						const offsetHeightAfter = domFigure.offsetHeight; // eslint-disable-line no-unused-vars
 					} );
 				}
 

--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -195,6 +195,7 @@ export default class ImageUploadEditing extends Plugin {
 
 				// Force re–paint in Safari. Without it, the image will display with a wrong size.
 				// https://github.com/ckeditor/ckeditor5/issues/1975
+				/* istanbul ignore next */
 				if ( env.isSafari ) {
 					editor.editing.view.once( 'render', () => {
 						// Early returns just to be safe. There might be some code ran

--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -204,7 +204,7 @@ export default class ImageUploadEditing extends Plugin {
 							return;
 						}
 
-						const domFigure = editor.editing.view.domConverter.mapDomToView( viewImg.parent );
+						const domFigure = editor.editing.view.domConverter.mapViewToDom( viewImg.parent );
 
 						if ( !domFigure ) {
 							return;
@@ -214,7 +214,8 @@ export default class ImageUploadEditing extends Plugin {
 
 						domFigure.style.display = 'none';
 
-						const offsetHeightBefore = domFigure.offsetHeight; // eslint-disable-line no-unused-vars
+						// Make sure this line will never be removed during minification for having "no effect".
+						domFigure._ckHack = domFigure.offsetHeight;
 
 						domFigure.style.display = originalDisplay;
 					} );

--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -196,14 +196,14 @@ export default class ImageUploadEditing extends Plugin {
 				// Force re–paint in Safari. Without it, the image will display with a wrong size.
 				// https://github.com/ckeditor/ckeditor5/issues/1975
 				if ( env.isSafari ) {
-					editor.ui.once( 'update', () => {
+					editor.editing.view.once( 'render', () => {
 						// Early returns just to be safe. There might be some code ran
 						// in between the outer scope and this callback.
 						if ( !viewImg.parent ) {
 							return;
 						}
 
-						const domFigure = editor.editing.view.domConverter.viewToDom( viewImg.parent );
+						const domFigure = editor.editing.view.domConverter.mapDomToView( viewImg.parent );
 
 						if ( !domFigure ) {
 							return;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Worked around Safari's image size bug. Closes ckeditor/ckeditor5#1975.