### PR TITLE
Fixed image resize flashing unexpected size

### DIFF
--- a/src/imageresize.js
+++ b/src/imageresize.js
@@ -58,6 +58,7 @@ export default class ImageResize extends Plugin {
 					modelElement: data.item,
 					viewElement: widget,
 					downcastWriter: conversionApi.writer,
+					editor,
 
 					getHandleHost( domWidgetElement ) {
 						return domWidgetElement.querySelector( 'img' );

--- a/src/imageresize.js
+++ b/src/imageresize.js
@@ -57,7 +57,6 @@ export default class ImageResize extends Plugin {
 
 					modelElement: data.item,
 					viewElement: widget,
-					downcastWriter: conversionApi.writer,
 					editor,
 
 					getHandleHost( domWidgetElement ) {

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -776,6 +776,19 @@ describe( 'ImageResize', () => {
 				}
 			} )();
 		} );
+
+		it( 'restores toolbar when clicking the handle without drag', () => {
+			// (https://github.com/ckeditor/ckeditor5-widget/pull/112#pullrequestreview-337725256).
+			const resizerPosition = 'bottom-left';
+			const domParts = getWidgetDomParts( widget, resizerPosition );
+			const initialPointerPosition = getResizerCoordinates( domParts.figure, resizerPosition );
+
+			focusEditor( editor );
+			fireMouseEvent( domParts.resizeHandle, 'mousedown', initialPointerPosition );
+			fireMouseEvent( domParts.resizeHandle, 'mouseup', initialPointerPosition );
+
+			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+		} );
 	} );
 
 	function isVisible( element ) {

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -13,6 +13,8 @@ import Image from '../src/image';
 import ImageResize from '../src/imageresize';
 import ImageResizeCommand from '../src/imageresize/imageresizecommand';
 import ImageStyle from '../src/imagestyle';
+import ImageToolbar from '../src/imagetoolbar';
+import ImageTextAlternative from '../src/imagetextalternative';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 
@@ -702,6 +704,79 @@ describe( 'ImageResize', () => {
 			resizer.isEnabled = false;
 
 			expect( resizerWrapper.style.display ).to.equal( 'none' );
+		} );
+	} );
+
+	describe( 'widget toolbar integration', () => {
+		let widgetToolbarRepository;
+
+		beforeEach( () => createEditor( {
+			plugins: [ Image, ImageStyle, Paragraph, Undo, Table, ImageResize, ImageToolbar, ImageTextAlternative ],
+			image: {
+				toolbar: [ 'imageTextAlternative' ],
+				resizeUnit: 'px'
+			}
+		} ) );
+
+		beforeEach( async () => {
+			setData( editor.model, `<paragraph>foo</paragraph>[<image src="${ IMAGE_SRC_FIXTURE }"></image>]` );
+
+			widget = viewDocument.getRoot().getChild( 1 );
+
+			widgetToolbarRepository = editor.plugins.get( 'WidgetToolbarRepository' );
+		} );
+
+		it( 'visibility during resize', async () => {
+			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+
+			await generateResizeTest( {
+				expectedWidth: 100,
+				modelRegExp: /.+/,
+				pointerOffset: {
+					x: 0,
+					y: 0
+				},
+				resizerPosition: 'bottom-right',
+				checkBeforeMouseUp: () => {
+					expect( widgetToolbarRepository.isEnabled ).to.be.false;
+				}
+			} )();
+		} );
+
+		it( 'visibility after the resize', async () => {
+			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+
+			await generateResizeTest( {
+				expectedWidth: 100,
+				modelRegExp: /.+/,
+				pointerOffset: {
+					x: 0,
+					y: 0
+				},
+				resizerPosition: 'bottom-right'
+			} )();
+
+			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+		} );
+
+		it( 'visibility after resize was canceled', async () => {
+			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+
+			const resizer = getSelectedImageResizer( editor );
+
+			await generateResizeTest( {
+				expectedWidth: 100,
+				modelRegExp: /.+/,
+				pointerOffset: {
+					x: 0,
+					y: 0
+				},
+				resizerPosition: 'bottom-right',
+				checkBeforeMouseUp: () => {
+					resizer.cancel();
+					expect( widgetToolbarRepository.isEnabled ).to.be.true;
+				}
+			} )();
 		} );
 	} );
 

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -323,7 +323,6 @@ describe( 'ImageResize', () => {
 		} );
 
 		it( 'shrinks correctly with left-bottom handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 80,
 			pointerOffset: {
 				x: 20,
@@ -333,7 +332,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'shrinks correctly with right-bottom handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 80,
 			pointerOffset: {
 				x: -20,
@@ -343,7 +341,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'shrinks correctly with left-top handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 80,
 			pointerOffset: {
 				x: 20,
@@ -353,7 +350,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'shrinks correctly with right-top handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 80,
 			pointerOffset: {
 				x: -20,
@@ -363,7 +359,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with left-bottom handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 120,
 			pointerOffset: {
 				x: -10,
@@ -373,7 +368,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with right-bottom handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 120,
 			pointerOffset: {
 				x: 10,
@@ -383,7 +377,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with right-bottom handler, y axis only', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 140,
 			pointerOffset: {
 				x: 0,
@@ -393,7 +386,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with right-bottom handler, x axis only', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 140,
 			pointerOffset: {
 				x: 40,
@@ -403,7 +395,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with left-top handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 120,
 			pointerOffset: {
 				x: -20,
@@ -413,7 +404,6 @@ describe( 'ImageResize', () => {
 		} ) );
 
 		it( 'enlarges correctly with right-top handler', generateSideResizeTest( {
-			isSideImage: true,
 			expectedWidth: 120,
 			pointerOffset: {
 				x: 20,
@@ -442,7 +432,6 @@ describe( 'ImageResize', () => {
 
 		function generateSideResizeTest( options ) {
 			return generateResizeTest( Object.assign( {
-				isSideImage: true,
 				modelRegExp: /<paragraph>foo<\/paragraph><image imageStyle="side" src=".+?" width="([\d.]+)px"><\/image>/
 			}, options ) );
 		}
@@ -722,7 +711,6 @@ describe( 'ImageResize', () => {
 		// options.pointerOffset - object - pointer offset relative to the dragged corner. Negative values are perfectly fine.
 		// e.g. { x: 10, y: -5 }
 		// options.expectedWidth
-		// [options.isSideImage=false]
 		// Returns a test case that puts
 		return async function() {
 			const domParts = getWidgetDomParts( widget, options.resizerPosition );

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -726,7 +726,7 @@ describe( 'ImageResize', () => {
 			widgetToolbarRepository = editor.plugins.get( 'WidgetToolbarRepository' );
 		} );
 
-		it( 'visibility during resize', async () => {
+		it( 'visibility during the resize', async () => {
 			expect( widgetToolbarRepository.isEnabled ).to.be.true;
 
 			await generateResizeTest( {
@@ -759,7 +759,7 @@ describe( 'ImageResize', () => {
 			expect( widgetToolbarRepository.isEnabled ).to.be.true;
 		} );
 
-		it( 'visibility after resize was canceled', async () => {
+		it( 'visibility after the resize was canceled', async () => {
 			expect( widgetToolbarRepository.isEnabled ).to.be.true;
 
 			const resizer = getSelectedImageResizer( editor );

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -412,6 +412,25 @@ describe( 'ImageResize', () => {
 			resizerPosition: 'top-right'
 		} ) );
 
+		it( 'doesn\'t flicker at the beginning of the resize', async () => {
+			// (#5189)
+			const resizerPosition = 'bottom-left';
+			const domParts = getWidgetDomParts( widget, resizerPosition );
+			const initialPointerPosition = getResizerCoordinates( domParts.figure, resizerPosition );
+			const resizeWrapperView = widget.getChild( 1 );
+
+			focusEditor( editor );
+			fireMouseEvent( domParts.resizeHandle, 'mousedown', initialPointerPosition );
+
+			await wait( 40 );
+
+			fireMouseEvent( domParts.resizeHandle, 'mousemove', initialPointerPosition );
+
+			expect( resizeWrapperView.getStyle( 'width' ) ).to.be.equal( '100px' );
+
+			fireMouseEvent( domParts.resizeHandle, 'mouseup', initialPointerPosition );
+		} );
+
 		it( 'makes no change when clicking the handle without drag', () => {
 			const resizerPosition = 'bottom-left';
 			const expectedWidth = 100;

--- a/tests/imageresize.js
+++ b/tests/imageresize.js
@@ -726,9 +726,11 @@ describe( 'ImageResize', () => {
 			widgetToolbarRepository = editor.plugins.get( 'WidgetToolbarRepository' );
 		} );
 
-		it( 'visibility during the resize', async () => {
+		it( 'default toolbar visibility', async () => {
 			expect( widgetToolbarRepository.isEnabled ).to.be.true;
+		} );
 
+		it( 'visibility during the resize', async () => {
 			await generateResizeTest( {
 				expectedWidth: 100,
 				modelRegExp: /.+/,
@@ -744,8 +746,6 @@ describe( 'ImageResize', () => {
 		} );
 
 		it( 'visibility after the resize', async () => {
-			expect( widgetToolbarRepository.isEnabled ).to.be.true;
-
 			await generateResizeTest( {
 				expectedWidth: 100,
 				modelRegExp: /.+/,
@@ -760,8 +760,6 @@ describe( 'ImageResize', () => {
 		} );
 
 		it( 'visibility after the resize was canceled', async () => {
-			expect( widgetToolbarRepository.isEnabled ).to.be.true;
-
 			const resizer = getSelectedImageResizer( editor );
 
 			await generateResizeTest( {

--- a/tests/manual/imageresize.js
+++ b/tests/manual/imageresize.js
@@ -32,6 +32,10 @@ const commonConfig = {
 			'side' // Purposely using side image instead right aligned image to make sure it works well with both style types.
 		]
 	},
+	table: {
+		contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
+		tableToolbar: [ 'bold', 'italic' ]
+	},
 	cloudServices: CS_CONFIG
 };
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed image resize behavior upon short clicking a handle without dragging. Image will no longer became full width, nor will it briefly flash an unexpected size. Closes ckeditor/ckeditor5#5189 and closes ckeditor/ckeditor5#5195.

MINOR BREAKING CHANGE: Resizer options object now also takes an editor instance.

MINOR BREAKING CHANGE: Removed the `downcastWriter` property from the [`ResizerOptions` interface](https://ckeditor.com/docs/ckeditor5/latest/api/module_widget_widgetresize-ResizerOptions.html).

---

### Additional information

Subpr of ckeditor/ckeditor5-widget#112.