### PR TITLE
Update logic for get 'img' form 'figure'.

### DIFF
--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -8,6 +8,7 @@
  */
 
 import first from '@ckeditor/ckeditor5-utils/src/first';
+import { getImgViewFromFigure } from './utils';
 
 /**
  * Returns a function that converts the image view representation:
@@ -81,7 +82,7 @@ export function srcsetAttributeConverter() {
 
 		const writer = conversionApi.writer;
 		const figure = conversionApi.mapper.toViewElement( data.item );
-		const img = figure.getChild( 0 );
+		const img = getImgViewFromFigure( figure );
 
 		if ( data.attributeNewValue === null ) {
 			const srcset = data.attributeOldValue;
@@ -122,7 +123,7 @@ export function modelToViewAttributeConverter( attributeKey ) {
 
 		const viewWriter = conversionApi.writer;
 		const figure = conversionApi.mapper.toViewElement( data.item );
-		const img = figure.getChild( 0 );
+		const img = getImgViewFromFigure( figure );
 
 		if ( data.attributeNewValue !== null ) {
 			viewWriter.setAttribute( data.attributeKey, data.attributeNewValue, img );

--- a/src/image/converters.js
+++ b/src/image/converters.js
@@ -36,7 +36,7 @@ export function viewFigureToModel() {
 		}
 
 		// Find an image element inside the figure element.
-		const viewImage = Array.from( data.viewItem.getChildren() ).find( viewChild => viewChild.is( 'img' ) );
+		const viewImage = getImgViewFromFigure( data.viewItem );
 
 		// Do not convert if image element is absent, is missing src attribute or was already converted.
 		if ( !viewImage || !viewImage.hasAttribute( 'src' ) || !conversionApi.consumable.test( viewImage, { name: true } ) ) {

--- a/src/image/utils.js
+++ b/src/image/utils.js
@@ -25,7 +25,7 @@ export function toImageWidget( viewElement, writer, label ) {
 	return toWidget( viewElement, writer, { label: labelCreator } );
 
 	function labelCreator() {
-		const imgElement = viewElement.getChild( 0 );
+		const imgElement = getImgViewFromFigure( viewElement );
 		const altText = imgElement.getAttribute( 'alt' );
 
 		return altText ? `${ altText } ${ label }` : label;
@@ -105,6 +105,20 @@ export function isImageAllowed( model ) {
 	return isImageAllowedInParent( selection, schema, model ) &&
 		!checkSelectionOnObject( selection, schema ) &&
 		isInOtherImage( selection );
+}
+
+/**
+ * Get img view element from the figure view.
+ *
+ * Using figureView.getChild(0) - is unsafe,
+ * because there are can be "figcaption" or smth else.
+ * This approach provide ability to extend plugin logic with other custom plugins.
+ *
+ * @param {module:engine/view/element~Element} figureView
+ * @returns {module:engine/view/element~Element}
+ */
+export function getImgViewFromFigure( figureView ) {
+	return Array.from( figureView.getChildren() ).find( viewChild => viewChild.is( 'img' ) );
 }
 
 // Checks if image is allowed by schema in optimal insertion parent.

--- a/src/imageupload/imageuploadediting.js
+++ b/src/imageupload/imageuploadediting.js
@@ -17,6 +17,7 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
 import ImageUploadCommand from '../../src/imageupload/imageuploadcommand';
 import { fetchLocalImage, isLocalImage } from '../../src/imageupload/utils';
 import { createImageTypeRegExp } from './utils';
+import { getImgViewFromFigure } from '../image/utils';
 
 /**
  * The editing part of the image upload feature. It registers the `'imageUpload'` command.
@@ -217,7 +218,7 @@ export default class ImageUploadEditing extends Plugin {
 				/* istanbul ignore next */
 				if ( env.isSafari ) {
 					const viewFigure = editor.editing.mapper.toViewElement( imageElement );
-					const viewImg = viewFigure.getChild( 0 );
+					const viewImg = getImgViewFromFigure( viewFigure );
 
 					editor.editing.view.once( 'render', () => {
 						// Early returns just to be safe. There might be some code ran

--- a/src/imageupload/imageuploadprogress.js
+++ b/src/imageupload/imageuploadprogress.js
@@ -13,6 +13,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import FileRepository from '@ckeditor/ckeditor5-upload/src/filerepository';
 import uploadingPlaceholder from '../../theme/icons/image_placeholder.svg';
 import env from '@ckeditor/ckeditor5-utils/src/env';
+import { getImgViewFromFigure } from '../image/utils';
 
 import '../../theme/imageuploadprogress.css';
 import '../../theme/imageuploadicon.css';
@@ -143,7 +144,7 @@ function _showPlaceholder( placeholder, viewFigure, writer ) {
 		writer.addClass( 'ck-image-upload-placeholder', viewFigure );
 	}
 
-	const viewImg = viewFigure.getChild( 0 );
+	const viewImg = getImgViewFromFigure( viewFigure );
 
 	if ( viewImg.getAttribute( 'src' ) !== placeholder ) {
 		writer.setAttribute( 'src', placeholder, viewImg );
@@ -270,7 +271,7 @@ function _removeUIElement( viewFigure, writer, uniqueProperty ) {
 // @param {module:upload/filerepository~FileLoader} loader
 function _displayLocalImage( viewFigure, writer, loader ) {
 	if ( loader.data ) {
-		const viewImg = viewFigure.getChild( 0 );
+		const viewImg = getImgViewFromFigure( viewFigure );
 
 		writer.setAttribute( 'src', loader.data, viewImg );
 	}


### PR DESCRIPTION
Update logic for get `img` form `figure` view element.
Fix strange behaviour with custom extending plugins with downcasting images attributes.
Issue describes here: https://github.com/ckeditor/ckeditor5/issues/6294

Default behaviour for getting img-view element was : `.getChild( 0 )` it is not best when we have some tags before img 'tag'. It can be possible in future...

Suggested behaviour: 
`Array.from( figureView.getChildren() ).find( viewChild => viewChild.is( 'img' ) );`

and encapsulate it to utils function `getImgViewFromFigure()`.

This approach provide ability to extend plugin logic with other custom plugins.

---
